### PR TITLE
add keyboard shortcut (M) to cycle scene geometry mode

### DIFF
--- a/src/components/Scene/CanvasKeyHandler.tsx
+++ b/src/components/Scene/CanvasKeyHandler.tsx
@@ -9,6 +9,7 @@ import {
   playbackJumpAction,
   changeControlsModeAction,
   changePlaySpeedAction,
+  changeSceneModeAction,
   toggleSettingsOptionAction,
 } from '@zus/actions'
 
@@ -27,6 +28,7 @@ export const CanvasKeyHandler = () => {
   const togglePlayback = () => dispatch(togglePlaybackAction())
   const playbackJump = (direction: any) => dispatch(playbackJumpAction(direction))
   const changePlaySpeed = (speed: any) => dispatch(changePlaySpeedAction(speed))
+  const changeSceneMode = (mode: any) => dispatch(changeSceneModeAction(mode))
   const changeControlsMode = (mode: any, options?: any) =>
     dispatch(changeControlsModeAction(mode, options))
   const toggleSettingsOption = (option: any) => dispatch(toggleSettingsOptionAction(option))
@@ -63,11 +65,15 @@ export const CanvasKeyHandler = () => {
             changePlaySpeed('slower')
             break
 
+          case 'm':
+            changeSceneMode(null)
+            break
+
           case 'n':
             toggleSettingsOption('ui.nameplate.enabled')
             break
 
-          case 'm':
+          case 'p':
             toggleSettingsOption('ui.xrayPlayers')
             break
 

--- a/src/components/UI/AboutPanel.tsx
+++ b/src/components/UI/AboutPanel.tsx
@@ -60,12 +60,16 @@ export const AboutPanel = () => {
               <br />
               - cp_gullywash
               <br />
+              - cp_metalworks
+              <br />
               - cp_process
               <br />
               - cp_snakewater
               <br />
               - cp_sunshine
-              <br />- koth_product_rcx
+              <br />
+              - koth_bagel
+              <br />- koth_product
             </p>
 
             <p>

--- a/src/components/UI/SettingsPanel.js
+++ b/src/components/UI/SettingsPanel.js
@@ -228,7 +228,7 @@ export const SettingsPanel = () => {
             Geometry
           </Divider>
 
-          <Option label="Material" leftClass="col" rightClass="col-auto">
+          <Option label="Material" leftClass="col" rightClass="col-auto" keyCode="M">
             <Button.Group size="tiny">
               <Button
                 compact
@@ -263,8 +263,8 @@ export const SettingsPanel = () => {
           </Divider>
 
           {/* <ToggleOption
-              label="Models through walls"
-              keyCode="M"
+              label="Player models through walls"
+              keyCode="P"
               checked={settings.ui.xrayPlayers}
               onChange={checked => updateSettingsOption('ui.xrayPlayers', checked)}
             /> */}

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -1,0 +1,7 @@
+export const SceneMode = {
+  WIREFRAME: 'wireframe',
+  UNTEXTURED: 'untextured',
+  TEXTURED: 'textured',
+} as const
+
+export type SceneMode = (typeof SceneMode)[keyof typeof SceneMode]

--- a/src/zustand/actions.js
+++ b/src/zustand/actions.js
@@ -9,6 +9,7 @@ import { PLAYBACK_SPEED_OPTIONS } from '@components/UI/PlaybackPanel'
 import { getSceneActors } from '@utils/scene'
 import { objCoordsToVector3 } from '@utils/geometry'
 import { CLASS_ORDER_MAP } from '@constants/mappings'
+import { SceneMode } from '@constants/types'
 
 import { dispatch, getState, useInstance } from './store'
 
@@ -193,6 +194,26 @@ export const jumpToFreeCamera = async (options = {}) => {
     await useInstance.getState().setFocusedObject(null)
   } catch (error) {
     console.error(error)
+  }
+}
+
+export const changeSceneModeAction = async (mode = undefined) => {
+  // If no mode provided, assume we wanna cycle the available modes
+  // TODO: improve this if typescripting/refactoring zustand
+  if (!mode) {
+    const currMode = getState().settings.scene.mode
+    const currIndex = Object.values(SceneMode).findIndex(value => value === currMode)
+    if (currIndex !== -1) {
+      const nextIndex = (currIndex + 1) % Object.values(SceneMode).length
+      const nextMode = Object.values(SceneMode)[nextIndex]
+      if (nextMode) {
+        mode = nextMode
+      }
+    }
+  }
+
+  if (mode) {
+    await dispatch(updateSettingsOptionAction('scene.mode', mode))
   }
 }
 

--- a/src/zustand/store.js
+++ b/src/zustand/store.js
@@ -2,6 +2,7 @@ import create from 'zustand'
 import { devtools, redux } from 'zustand/middleware'
 import * as THREE from 'three'
 
+import { SceneMode } from '@constants/types'
 import rootReducer from './reducer'
 
 // This "Instance Store" is meant to be used for larger objects that are problematic
@@ -67,7 +68,7 @@ const initialState = {
 
   settings: {
     scene: {
-      mode: 'untextured',
+      mode: SceneMode.UNTEXTURED,
     },
     camera: {
       orthographic: false,


### PR DESCRIPTION
- Add keyboard shortcut `M` to cycle through scene geometry mode (wireframe, untextured, textured)
- Update supported maps list