### PR TITLE
chore: cleanup some typescript warnings / redundancies

### DIFF
--- a/src/components/Scene/Lights.tsx
+++ b/src/components/Scene/Lights.tsx
@@ -6,7 +6,6 @@ export const Lights = () => {
       <ambientLight color="#ffffff" intensity={0.3} />
       <directionalLight color="#ffffff" intensity={1.5} position={[100, 100, 100]} />
       <directionalLight color="#ffffff" intensity={1.5} position={[-100, -100, 100]} />
-      {/* <hemisphereLight /> */}
     </group>
   )
 }

--- a/src/components/Scene/Nameplate.tsx
+++ b/src/components/Scene/Nameplate.tsx
@@ -2,7 +2,6 @@ import { clamp } from 'lodash'
 
 import { ClassIcon } from '@components/UI/ClassIcon'
 
-import { ACTOR_TEAM_COLORS } from '@constants/mappings'
 import { parseClassHealth } from '@utils/players'
 import { cn } from '@utils/styling'
 
@@ -17,7 +16,6 @@ export interface NameplateProps {
 export const Nameplate = (props: NameplateProps) => {
   const { health, classId, name, team, settings } = props
 
-  const healthColor = ACTOR_TEAM_COLORS(team).healthBar
   const { percentage } = parseClassHealth(classId, health)
 
   if (!settings.enabled) return null
@@ -38,10 +36,6 @@ export const Nameplate = (props: NameplateProps) => {
 
         {settings.showHealth && (
           <div className="relative mt-1 h-[6px] w-20 overflow-hidden bg-[#8f7b89]">
-            {/* Note: fill & overheal widths are manipulated inline for better performance,
-            because changing the value in css class directly will continously trigger
-            styled-jsx recalculation / DOM reflow (very costly over time)
-            https://github.com/vercel/styled-jsx#via-inline-style */}
             <div
               className={cn(
                 'absolute inset-0 right-auto',

--- a/src/components/Scene/Projectiles.tsx
+++ b/src/components/Scene/Projectiles.tsx
@@ -74,7 +74,7 @@ export interface BaseProjectileProps extends CachedProjectile {}
 //
 
 export const RocketProjectile = (props: BaseProjectileProps) => {
-  const ref = useRef<THREE.Group>()
+  const ref = useRef<THREE.Group>(null)
   const prevPosition = useRef<THREE.Vector3>(objCoordsToVector3(props.position))
   const position = objCoordsToVector3(props.position)
 

--- a/src/components/Scene/World.tsx
+++ b/src/components/Scene/World.tsx
@@ -25,7 +25,7 @@ export interface WorldProps {
 }
 
 export const World = (props: WorldProps) => {
-  const ref = useRef<THREE.Group>()
+  const ref = useRef<THREE.Group>(null)
   const [mapModel, setMapModel] = useState<THREE.Group | null>()
   const [mapOverlay, setMapOverlay] = useState<THREE.Group | null>()
   const { map, mode } = props
@@ -81,8 +81,8 @@ export const World = (props: WorldProps) => {
     if (mapOverlay) {
       mapOverlay.traverse((child: THREE.Object3D) => {
         traverseMaterials(child, (material: any) => {
-          if (material.map) material.map.encoding = THREE.sRGBEncoding
-          if (material.emissiveMap) material.emissiveMap.encoding = THREE.sRGBEncoding
+          // if (material.map) material.map.encoding = THREE.sRGBEncoding
+          // if (material.emissiveMap) material.emissiveMap.encoding = THREE.sRGBEncoding
           material.depthWrite = true
           material.needsUpdate = true
 
@@ -100,8 +100,8 @@ export const World = (props: WorldProps) => {
     if (mapModel) {
       mapModel.traverse((child: THREE.Object3D) => {
         traverseMaterials(child, (material: any, node: any) => {
-          if (material.map) material.map.encoding = THREE.sRGBEncoding
-          if (material.emissiveMap) material.emissiveMap.encoding = THREE.sRGBEncoding
+          // if (material.map) material.map.encoding = THREE.sRGBEncoding
+          // if (material.emissiveMap) material.emissiveMap.encoding = THREE.sRGBEncoding
           material.depthWrite = true
           material.vertexColors = false
           material.needsUpdate = true
@@ -162,7 +162,7 @@ function loadGLTF(file: string) {
         }
       }
 
-      const onError = (error: ErrorEvent) => {
+      const onError = (error: unknown) => {
         throw error
       }
 

--- a/src/components/UI/Killfeed.tsx
+++ b/src/components/UI/Killfeed.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { inRange } from 'lodash'
 
 import { AsyncParser, CachedDeath } from '@components/Analyse/Data/AsyncParser'
@@ -41,13 +42,9 @@ export const KillfeedItem = (props: KillfeedItemProps) => {
   const { killer, assister, victim, weapon } = props.death
 
   let iconName = KILL_ICON_ALIASES[weapon] || weapon
-  let weaponIcon
-  try {
-    weaponIcon = new URL(`/src/assets/kill_icons/${iconName}.png`, import.meta.url).href
-  } catch (e) {
-    console.log(`Missing kill icon: ${iconName}`)
-    weaponIcon = new URL(`/src/assets/kill_icons/skull.png`, import.meta.url).href
-  }
+  let [weaponIcon, setWeaponIcon] = useState(
+    new URL(`/src/assets/kill_icons/${iconName}.png`, import.meta.url).href
+  )
 
   const teamTextColorMap: { [key: string]: string } = {
     red: 'text-pp-killfeed-text-red',
@@ -55,6 +52,11 @@ export const KillfeedItem = (props: KillfeedItemProps) => {
   }
   let killerTeamColor = killer ? teamTextColorMap[killer.user.team] : ''
   let victimTeamColor = teamTextColorMap[victim?.user.team]
+
+  const onWeaponIconImgError = () => {
+    console.log(`Missing kill icon: ${iconName}`)
+    setWeaponIcon(new URL(`/src/assets/kill_icons/skull.png`, import.meta.url).href)
+  }
 
   return (
     <>
@@ -68,7 +70,12 @@ export const KillfeedItem = (props: KillfeedItemProps) => {
         {assister && <div className={cn(killerTeamColor)}>{assister.user.name}</div>}
 
         <div className="inline-flex items-center px-4">
-          <img src={weaponIcon} className="h-[1.2rem] brightness-[600%]" alt={`${weapon} Icon`} />
+          <img
+            src={weaponIcon}
+            className="h-[1.2rem] brightness-[600%]"
+            alt={`${weapon} Icon`}
+            onError={onWeaponIconImgError}
+          />
         </div>
 
         <div className={cn(victimTeamColor)}>{victim.user.name}</div>

--- a/src/components/UI/PlayerStatuses.tsx
+++ b/src/components/UI/PlayerStatuses.tsx
@@ -163,11 +163,6 @@ export const StatusItem = (props: StatusItemProps) => {
             alignment === 'right' && 'flex-row-reverse'
           )}
         >
-          {/* Note: fill & overheal widths are manipulated inline for better performance,
-            because changing the value in css class directly will continously trigger
-            styled-jsx recalculation / DOM reflow (very costly over time)
-            https://github.com/vercel/styled-jsx#via-inline-style */}
-
           {/* Fill */}
           <div
             className={cn(

--- a/src/components/UI/SettingsPanel.tsx
+++ b/src/components/UI/SettingsPanel.tsx
@@ -261,6 +261,7 @@ export const SettingsPanel = () => {
                 { label: 'Textured', value: 'textured' },
               ].map(button => (
                 <button
+                  key={`select-material-btn-${button.value}`}
                   className={cn(
                     'rounded-xl border px-2 text-sm',
                     settings.scene.mode === button.value && 'border-[#3273f6] bg-[#3273f6]'

--- a/src/constants/mappings.ts
+++ b/src/constants/mappings.ts
@@ -44,46 +44,6 @@ export const TEAM_MAP: { [key: number]: string } = {
   3: 'blue',
 }
 
-export const ACTOR_TEAM_COLORS: any = (team: string) => {
-  switch (team) {
-    case 'red':
-      return {
-        // actorModel: '#ff0202', //'#de4a50',
-        // healthBar: '#ac2641',
-        // healthOverhealed: '#4dd241',
-        // healthLow: '#ff6262',
-        // killfeedText: '#ff4a4a',
-        // focusedBackground: '#ac2641',
-        // pipebombColor: '#ff2525',
-        // stickybombColor: '#ff0202',
-      }
-
-    case 'blue':
-      return {
-        // actorModel: '#0374ff', //'#559dc1',
-        // healthBar: '#88aeb8',
-        // healthOverhealed: '#4dd241',
-        // healthLow: '#ff6262',
-        // killfeedText: '#77a9ec',
-        // focusedBackground: '#88aeb8',
-        // pipebombColor: '#142bff',
-        // stickybombColor: '#0037ff',
-      }
-
-    default:
-      return {
-        actorModel: '#f800d7',
-        healthBar: '#f800d7',
-        healthOverhealed: '#f800d7',
-        healthLow: '#f800d7',
-        killfeedText: '#ffffff',
-        focusedBackground: '#f800d7',
-        pipebombColor: '#f800d7',
-        stickybombColor: '#f800d7',
-      }
-  }
-}
-
 // Used for checking a demo's map name against (key)
 // and returning the (value) if found.
 // This is helpful to allow using the same map gltf model for

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -98,29 +98,3 @@ export const getMeshes = (sceneObjects: THREE.Object3D[], meshName: string = '')
 
   return meshes
 }
-
-/**
- * Find all skinned meshes in an Object3D array (can specify specific mesh name)
- */
-export const getSkinnedMeshes = (
-  sceneObjects: THREE.Object3D[],
-  meshName: string = ''
-): THREE.SkinnedMesh[] => {
-  const meshes: THREE.SkinnedMesh[] = []
-
-  sceneObjects.forEach(object => {
-    object.traverse(child => {
-      if (child.type === 'SkinnedMesh') {
-        if (meshName) {
-          if (child.name === meshName) {
-            meshes.push(child as THREE.SkinnedMesh)
-          }
-        } else {
-          meshes.push(child as THREE.SkinnedMesh)
-        }
-      }
-    })
-  })
-
-  return meshes
-}

--- a/src/zustand/actions.ts
+++ b/src/zustand/actions.ts
@@ -17,7 +17,7 @@ import { dispatch, getState, useInstance } from './store'
 // ─── PARSER ─────────────────────────────────────────────────────────────────────
 //
 
-export const parseDemoAction = async fileBuffer => {
+export const parseDemoAction = async (fileBuffer: ArrayBuffer) => {
   try {
     dispatch({ type: 'PARSE_DEMO_INIT' })
 
@@ -51,7 +51,7 @@ export const parseDemoAction = async fileBuffer => {
 // ─── SCENE ──────────────────────────────────────────────────────────────────────
 //
 
-export const loadSceneFromDemoAction = async parsedDemo => {
+export const loadSceneFromDemoAction = async (parsedDemo: AsyncParser) => {
   try {
     toggleUIPanelAction('About', false)
 
@@ -247,7 +247,7 @@ export const goToTickAction = async (tick: number) => {
   }
 }
 
-export const playbackJumpAction = async direction => {
+export const playbackJumpAction = async (direction: string) => {
   try {
     const PLAYBACK_JUMP_TICK_INCREMENT = 50
     const tick = getState().playback.tick
@@ -294,7 +294,7 @@ export const togglePlaybackAction = async (playing = undefined) => {
   }
 }
 
-export const changePlaySpeedAction = async speed => {
+export const changePlaySpeedAction = async (speed: 'faster' | 'slower' | number) => {
   try {
     // Provide the option to pass strings "faster" or "slower" as the {speed} param instead
     // which will simply cycle the options as defined in PlaybackPanel

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,13 +5,5 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: [['styled-jsx/babel', { plugins: ['@styled-jsx/plugin-sass'] }]],
-      },
-    }),
-    tsconfigPaths(),
-    nodePolyfills({ include: ['events'] }),
-  ],
+  plugins: [react(), tsconfigPaths(), nodePolyfills({ include: ['events'] })],
 })


### PR DESCRIPTION
- remove lingering styled-jsx dependency in vite config
- proper fallback of missing kill icons
- update refs with default `null`
- fix misc type warnings
- remove color mapping (rely on tailwind now)
- remove unused stuff (from upgrading THREE, things better off gone)