### PR TITLE
refactor: use local icons & little UX improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@bryjch/demo.js": "git+https://github.com/bryjch/demo.js.git",
-    "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@react-three/fiber": "^8.16.1",
     "@react-three/postprocessing": "^2.16.2",

--- a/src/components/Misc/DemoDrawing.tsx
+++ b/src/components/Misc/DemoDrawing.tsx
@@ -2,7 +2,8 @@ import { useRef, useState, useLayoutEffect, CSSProperties } from 'react'
 import CanvasDraw from 'react-canvas-draw'
 import { motion } from 'framer-motion'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { ReloadIcon, TrashIcon } from '@radix-ui/react-icons'
+
+import { FaTrashIcon, FaUndoIcon } from './Icons'
 
 import { useStore, useInstance } from '@zus/store'
 import { cn } from '@utils/styling'
@@ -89,7 +90,8 @@ export const DemoDrawing = () => {
               <div
                 key={`drawing-brush-color-option-${color}`}
                 className={cn(
-                  'mx-2 h-10 w-10 cursor-pointer rounded-full [border:3px_solid_transparent] [transition:0.3s_ease_all]',
+                  'mx-2 h-10 w-10 cursor-pointer rounded-full hover:scale-125',
+                  '[border:3px_solid_transparent] [transition:0.3s_ease_all]',
                   brushColor === color && 'scale-125 [border:3px_solid_white]'
                 )}
                 style={{ backgroundColor: color }}
@@ -105,10 +107,10 @@ export const DemoDrawing = () => {
               <Tooltip.Root>
                 <Tooltip.Trigger asChild>
                   <div
-                    className="inline-block cursor-pointer"
+                    className="inline-block cursor-pointer transition-all hover:scale-125"
                     onClick={drawingCanvasRef.current?.undo}
                   >
-                    <ReloadIcon className="scale-x-[-1]" />
+                    <FaUndoIcon />
                   </div>
                 </Tooltip.Trigger>
 
@@ -130,7 +132,7 @@ export const DemoDrawing = () => {
                 <div
                   key={`drawing-brush-radius-option-${size}`}
                   className={cn(
-                    'cursor-pointer select-none px-2 py-1 text-lg',
+                    'cursor-pointer select-none px-2 py-1 text-lg hover:underline',
                     brushRadius === size && 'font-bold underline',
                     `option ${brushRadius === size ? 'active' : ''}`
                   )}
@@ -147,10 +149,10 @@ export const DemoDrawing = () => {
               <Tooltip.Root>
                 <Tooltip.Trigger asChild>
                   <div
-                    className="inline-block cursor-pointer"
+                    className="inline-block cursor-pointer transition-all hover:scale-125"
                     onClick={drawingCanvasRef.current?.clear}
                   >
-                    <TrashIcon className="h-5 w-5" />
+                    <FaTrashIcon className="h-5 w-5" />
                   </div>
                 </Tooltip.Trigger>
 

--- a/src/components/Misc/Icons.tsx
+++ b/src/components/Misc/Icons.tsx
@@ -1,0 +1,141 @@
+import { SVGProps } from 'react'
+
+// Source: https://react-icons.github.io/react-icons
+
+export const AiFillStepForwardIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 1024 1024"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M676.4 528.95L293.2 829.97c-14.25 11.2-35.2 1.1-35.2-16.95V210.97c0-18.05 20.95-28.14 35.2-16.94l383.2 301.02a21.53 21.53 0 0 1 0 33.9M694 864h64a8 8 0 0 0 8-8V168a8 8 0 0 0-8-8h-64a8 8 0 0 0-8 8v688a8 8 0 0 0 8 8"></path>
+    </svg>
+  )
+}
+
+export const AiFillFastForwardIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 1024 1024"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M793.8 499.3L506.4 273.5c-10.7-8.4-26.4-.8-26.4 12.7v451.6c0 13.5 15.7 21.1 26.4 12.7l287.4-225.8a16.14 16.14 0 0 0 0-25.4zm-320 0L186.4 273.5c-10.7-8.4-26.4-.8-26.4 12.7v451.5c0 13.5 15.7 21.1 26.4 12.7l287.4-225.8c4.1-3.2 6.2-8 6.2-12.7 0-4.6-2.1-9.4-6.2-12.6zM857.6 248h-51.2c-3.5 0-6.4 2.7-6.4 6v516c0 3.3 2.9 6 6.4 6h51.2c3.5 0 6.4-2.7 6.4-6V254c0-3.3-2.9-6-6.4-6z"></path>{' '}
+    </svg>
+  )
+}
+
+export const IoMdPlayIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 512 512"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M96 52v408l320-204L96 52z"></path>
+    </svg>
+  )
+}
+
+export const IoMdPauseIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 512 512"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M96 448h106.7V64H96v384zM309.3 64v384H416V64H309.3z"></path>
+    </svg>
+  )
+}
+
+export const IoMdSettingsIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 512 512"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M413.967 276.8c1.06-6.235 1.06-13.518 1.06-20.8s-1.06-13.518-1.06-20.8l44.667-34.318c4.26-3.118 5.319-8.317 2.13-13.518L418.215 115.6c-2.129-4.164-8.507-6.235-12.767-4.164l-53.186 20.801c-10.638-8.318-23.394-15.601-36.16-20.801l-7.448-55.117c-1.06-4.154-5.319-8.318-10.638-8.318h-85.098c-5.318 0-9.577 4.164-10.637 8.318l-8.508 55.117c-12.767 5.2-24.464 12.482-36.171 20.801l-53.186-20.801c-5.319-2.071-10.638 0-12.767 4.164L49.1 187.365c-2.119 4.153-1.061 10.399 2.129 13.518L96.97 235.2c0 7.282-1.06 13.518-1.06 20.8s1.06 13.518 1.06 20.8l-44.668 34.318c-4.26 3.118-5.318 8.317-2.13 13.518L92.721 396.4c2.13 4.164 8.508 6.235 12.767 4.164l53.187-20.801c10.637 8.318 23.394 15.601 36.16 20.801l8.508 55.117c1.069 5.2 5.318 8.318 10.637 8.318h85.098c5.319 0 9.578-4.164 10.638-8.318l8.518-55.117c12.757-5.2 24.464-12.482 36.16-20.801l53.187 20.801c5.318 2.071 10.637 0 12.767-4.164l42.549-71.765c2.129-4.153 1.06-10.399-2.13-13.518l-46.8-34.317zm-158.499 52c-41.489 0-74.46-32.235-74.46-72.8s32.971-72.8 74.46-72.8 74.461 32.235 74.461 72.8-32.972 72.8-74.461 72.8z"></path>
+    </svg>
+  )
+}
+
+export const TiInfoLargeIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      version="1.2"
+      viewBox="0 0 24 24"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M13.839 17.525c-.006.002-.559.186-1.039.186-.265 0-.372-.055-.406-.079-.168-.117-.48-.336.054-1.4l1-1.994c.593-1.184.681-2.329.245-3.225-.356-.733-1.039-1.236-1.92-1.416-.317-.065-.639-.097-.958-.097-1.849 0-3.094 1.08-3.146 1.126-.179.158-.221.42-.102.626.12.206.367.3.595.222.005-.002.559-.187 1.039-.187.263 0 .369.055.402.078.169.118.482.34-.051 1.402l-1 1.995c-.594 1.185-.681 2.33-.245 3.225.356.733 1.038 1.236 1.921 1.416.314.063.636.097.954.097 1.85 0 3.096-1.08 3.148-1.126.179-.157.221-.42.102-.626-.12-.205-.369-.297-.593-.223z"></path>
+      <circle cx="13" cy="6.001" r="2.5"></circle>
+    </svg>
+  )
+}
+
+export const FaUndoIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 512 512"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M212.333 224.333H12c-6.627 0-12-5.373-12-12V12C0 5.373 5.373 0 12 0h48c6.627 0 12 5.373 12 12v78.112C117.773 39.279 184.26 7.47 258.175 8.007c136.906.994 246.448 111.623 246.157 248.532C504.041 393.258 393.12 504 256.333 504c-64.089 0-122.496-24.313-166.51-64.215-5.099-4.622-5.334-12.554-.467-17.42l33.967-33.967c4.474-4.474 11.662-4.717 16.401-.525C170.76 415.336 211.58 432 256.333 432c97.268 0 176-78.716 176-176 0-97.267-78.716-176-176-176-58.496 0-110.28 28.476-142.274 72.333h98.274c6.627 0 12 5.373 12 12v48c0 6.627-5.373 12-12 12z"></path>
+    </svg>
+  )
+}
+
+export const FaTrashIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      stroke-width="0"
+      viewBox="0 0 448 512"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M135.2 17.7L128 32H32C14.3 32 0 46.3 0 64S14.3 96 32 96H416c17.7 0 32-14.3 32-32s-14.3-32-32-32H320l-7.2-14.3C307.4 6.8 296.3 0 284.2 0H163.8c-12.1 0-23.2 6.8-28.6 17.7zM416 128H32L53.2 467c1.6 25.3 22.6 45 47.9 45H346.9c25.3 0 46.3-19.7 47.9-45L416 128z"></path>
+    </svg>
+  )
+}

--- a/src/components/UI/AboutPanel.tsx
+++ b/src/components/UI/AboutPanel.tsx
@@ -1,4 +1,5 @@
 import { TogglePanel } from '@components/UI/Shared/TogglePanel'
+import { TiInfoLargeIcon } from '@components/Misc/Icons'
 
 import { useStore } from '@zus/store'
 import { toggleUIPanelAction, parseDemoAction } from '@zus/actions'
@@ -30,7 +31,7 @@ export const AboutPanel = () => {
         className="mr-2 flex h-9 w-9 items-center justify-center bg-pp-panel/75"
         onClick={toggleUIPanel}
       >
-        ABT
+        <TiInfoLargeIcon />
       </button>
 
       <TogglePanel className="w-[360px] max-w-full bg-pp-panel/80" isOpen={isOpen}>

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -1,12 +1,11 @@
 import * as Tooltip from '@radix-ui/react-tooltip'
+
 import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  DoubleArrowLeftIcon,
-  DoubleArrowRightIcon,
-  PauseIcon,
-  PlayIcon,
-} from '@radix-ui/react-icons'
+  AiFillStepForwardIcon,
+  AiFillFastForwardIcon,
+  IoMdPauseIcon,
+  IoMdPlayIcon,
+} from '@components/Misc/Icons'
 
 import { useStore } from '@zus/store'
 import { goToTickAction, togglePlaybackAction, changePlaySpeedAction } from '@zus/actions'
@@ -14,11 +13,11 @@ import { focusMainCanvas } from '@utils/misc'
 import { cn } from '@utils/styling'
 
 export const PLAYBACK_SPEED_OPTIONS = [
-  { label: '3x', value: 3 },
-  { label: '2x', value: 2 },
-  { label: '1x', value: 1 },
-  { label: '0.5x', value: 0.5 },
-  { label: '0.1x', value: 0.1 },
+  { label: '3×', value: 3 },
+  { label: '2×', value: 2 },
+  { label: '1×', value: 1 },
+  { label: '0.5×', value: 0.5 },
+  { label: '0.1×', value: 0.1 },
 ]
 
 interface PlaybackActionProps {
@@ -32,7 +31,13 @@ const PlaybackAction = (props: PlaybackActionProps) => {
     <Tooltip.Provider delayDuration={0}>
       <Tooltip.Root>
         <Tooltip.Trigger asChild>
-          <div className="cursor-pointer" onClick={props.onClick}>
+          <div
+            className={cn(
+              'cursor-pointer opacity-80',
+              'transform transition-all hover:scale-125 hover:opacity-100'
+            )}
+            onClick={props.onClick}
+          >
             {props.icon}
           </div>
         </Tooltip.Trigger>
@@ -69,9 +74,11 @@ export const PlaybackPanel = () => {
 
   return (
     <div className="m-4 max-w-full">
-      <div className="pointer-events-none select-none">Tick #{tick * 2}</div>
+      <div className="pointer-events-none select-none text-sm tracking-widest">
+        TICK #{tick * 2}
+      </div>
 
-      <div className="mt-3 flex items-center justify-center gap-4">
+      <div className="mt-4 flex items-center justify-center gap-6">
         {/* Spacer to match play speed width (looks more balanced) */}
 
         <span className="w-[32px]" />
@@ -79,7 +86,7 @@ export const PlaybackPanel = () => {
         {/* Jump to start action */}
 
         <PlaybackAction
-          icon={<DoubleArrowLeftIcon width="2rem" height="2rem" />}
+          icon={<AiFillFastForwardIcon width="2rem" height="2rem" className="rotate-180" />}
           content={<div>Jump to start</div>}
           onClick={goToTick.bind(null, 1)}
         />
@@ -87,7 +94,7 @@ export const PlaybackPanel = () => {
         {/* Seek back action */}
 
         <PlaybackAction
-          icon={<ChevronLeftIcon width="2rem" height="2rem" />}
+          icon={<AiFillStepForwardIcon width="2rem" height="2rem" className="rotate-180" />}
           content={
             <div className="grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
               <div className="col-span-2 text-center">Seek back</div>
@@ -105,9 +112,9 @@ export const PlaybackPanel = () => {
         <PlaybackAction
           icon={
             playing ? (
-              <PauseIcon width="2rem" height="2rem" />
+              <IoMdPauseIcon width="2rem" height="2rem" />
             ) : (
-              <PlayIcon width="2rem" height="2rem" />
+              <IoMdPlayIcon width="2rem" height="2rem" />
             )
           }
           content={
@@ -121,7 +128,7 @@ export const PlaybackPanel = () => {
         {/* Seek forward action */}
 
         <PlaybackAction
-          icon={<ChevronRightIcon width="2rem" height="2rem" />}
+          icon={<AiFillStepForwardIcon width="2rem" height="2rem" />}
           content={
             <div className="grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
               <div className="col-span-2 text-center">Seek forward</div>
@@ -137,7 +144,7 @@ export const PlaybackPanel = () => {
         {/* Jump to end action */}
 
         <PlaybackAction
-          icon={<DoubleArrowRightIcon width="2rem" height="2rem" />}
+          icon={<AiFillFastForwardIcon width="2rem" height="2rem" />}
           content={<div>Jump to end</div>}
           onClick={goToTick.bind(null, maxTicks)}
         />
@@ -145,7 +152,11 @@ export const PlaybackPanel = () => {
         {/* Change play speed */}
 
         <PlaybackAction
-          icon={<div className="select-none text-xl font-medium">{speed}x</div>}
+          icon={
+            <div className="select-none rounded-3xl bg-white/90 px-2 text-sm text-black">
+              {speed}×
+            </div>
+          }
           content={
             <>
               <div className="text-center">Playback speed</div>

--- a/src/components/UI/SettingsPanel.tsx
+++ b/src/components/UI/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { clamp } from 'lodash'
 
 import { TogglePanel } from '@components/UI/Shared/TogglePanel'
+import { IoMdSettingsIcon } from '@components/Misc/Icons'
 
 import { useStore } from '@zus/store'
 import { toggleUIPanelAction, updateSettingsOptionAction } from '@zus/actions'
@@ -142,7 +143,7 @@ export const SettingsPanel = () => {
         className="mr-2 flex h-9 w-9 items-center justify-center bg-pp-panel/75"
         onClick={toggleUIPanel}
       >
-        SET
+        <IoMdSettingsIcon />
       </button>
 
       <TogglePanel className="w-[360px] max-w-full bg-pp-panel/80" isOpen={isOpen}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,11 +499,6 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-escape-keydown" "1.0.3"
 
-"@radix-ui/react-icons@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.3.0.tgz#c61af8f323d87682c5ca76b856d60c2312dbcb69"
-  integrity sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==
-
 "@radix-ui/react-id@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.1.tgz#73cdc181f650e4df24f0b6a5b7aa426b912c88c0"


### PR DESCRIPTION
Replace @radix-ui/react-icons as they are pretty limited.

Use local SVGs instead so less dependencies / tree shaking worries.

Make some UI things have more user response (e.g. scale on hover).