### PR TITLE
feat: better camera tip panels (add POV, RTS)

### DIFF
--- a/src/components/UI/CameraTipPanels.tsx
+++ b/src/components/UI/CameraTipPanels.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+
+import { useStore } from '@zus/store'
+import { usePointerLock } from '@utils/hooks'
+import { ControlsMode } from '@constants/types'
+
+export const useShowTimeout = (
+  controlsMode: ControlsMode,
+  { forceShow }: { forceShow?: boolean } = {}
+) => {
+  const activeControlsMode = useStore(state => state.scene.controls.mode)
+  const [showing, setShowing] = useState(false)
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout
+    if (activeControlsMode === controlsMode) {
+      setShowing(true)
+      timeout = setTimeout(() => setShowing(false), 2000)
+    }
+    return () => timeout && clearTimeout(timeout)
+  }, [activeControlsMode, forceShow])
+
+  return { showing: activeControlsMode === controlsMode && (showing || forceShow) }
+}
+
+export const POVCameraTipPanel = () => {
+  const { showing } = useShowTimeout('pov')
+
+  return (
+    <motion.div
+      className="absolute w-72 rounded-3xl bg-pp-panel/80 p-6"
+      animate={showing ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
+      transition={{ duration: 0.2 }}
+      initial={false}
+    >
+      <div className="mb-1 flex">
+        <strong>POV Camera</strong>
+      </div>
+
+      <motion.div>
+        <div className="mb-1 flex">
+          <span>Next player</span>
+          <div className="flex-1" />
+          <kbd>1</kbd>
+        </div>
+
+        <div className="flex">
+          <span>Previous player</span>
+          <div className="flex-1" />
+          <kbd>Shift + 1</kbd>
+        </div>
+      </motion.div>
+    </motion.div>
+  )
+}
+
+export const SpectatorCameraTipPanel = () => {
+  const { isPointerLocked } = usePointerLock()
+  const { showing } = useShowTimeout('spectator', { forceShow: !isPointerLocked })
+
+  return (
+    <motion.div
+      className="w-72 rounded-3xl bg-pp-panel/80 p-6"
+      animate={showing ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
+      transition={{ duration: 0.2 }}
+      initial={false}
+    >
+      <div className="mb-1 flex">
+        <strong>Spectator Camera</strong>
+        <div className="flex-1" />
+        <div>
+          {isPointerLocked ? (
+            <motion.div
+              key={`on`}
+              initial={{ opacity: 0, y: -2 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              style={{ color: '#4dd241' }}
+              className="px-2"
+            >
+              ON
+            </motion.div>
+          ) : (
+            <motion.div
+              key={`idle`}
+              initial={{ opacity: 0, y: -2 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3 }}
+              style={{ color: '#fa9e21' }}
+              className="px-2"
+            >
+              IDLE
+            </motion.div>
+          )}
+        </div>
+      </div>
+
+      {!isPointerLocked && (
+        <motion.div>
+          <div className="flex">
+            <span>Activate</span>
+            <div className="flex-1" />
+            <kbd>LMB</kbd>
+          </div>
+        </motion.div>
+      )}
+
+      {isPointerLocked && (
+        <motion.div>
+          <div className="mb-1 flex">
+            <span>Deactivate</span>
+            <div className="flex-1" />
+            <kbd>ESC</kbd> / <kbd>RMB</kbd>
+          </div>
+
+          <div className="mb-1 flex">
+            <span>Movement</span>
+            <div className="flex-1" />
+            <kbd className="ml-1">W</kbd>
+            <kbd className="ml-1">A</kbd>
+            <kbd className="ml-1">S</kbd>
+            <kbd className="ml-1">D</kbd>
+          </div>
+
+          <div className="mb-1 flex">
+            <span>Elevation</span>
+            <div className="flex-1" />
+
+            <kbd className="ml-1">E</kbd>
+            <kbd className="ml-1">C</kbd>
+          </div>
+
+          <div className="flex">
+            <span>Boost</span>
+            <div className="flex-1" />
+            <kbd>Shift</kbd>
+          </div>
+        </motion.div>
+      )}
+    </motion.div>
+  )
+}
+
+export const RtsCameraTipPanel = () => {
+  const { showing } = useShowTimeout('rts')
+
+  return (
+    <motion.div
+      className="absolute w-72 rounded-3xl bg-pp-panel/80 p-6"
+      animate={showing ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
+      transition={{ duration: 0.2 }}
+      initial={false}
+    >
+      <div className="mb-1 flex">
+        <strong>RTS Camera</strong>
+      </div>
+
+      <motion.div>
+        <div className="mb-1 flex">
+          <span>Rotate</span>
+          <div className="flex-1" />
+          <kbd>LMB</kbd>
+        </div>
+
+        <div className="mb-1 flex">
+          <span>Pan</span>
+          <div className="flex-1" />
+          <kbd>RMB</kbd>
+        </div>
+
+        <div className="mb-1 flex">
+          <span>Movement</span>
+          <div className="flex-1" />
+          <kbd className="ml-1">W</kbd>
+          <kbd className="ml-1">A</kbd>
+          <kbd className="ml-1">S</kbd>
+          <kbd className="ml-1">D</kbd>
+        </div>
+
+        <div className="flex">
+          <span>Zoom</span>
+          <div className="flex-1" />
+          <kbd>Scroll</kbd>
+        </div>
+      </motion.div>
+    </motion.div>
+  )
+}

--- a/src/components/UI/SettingsPanel.tsx
+++ b/src/components/UI/SettingsPanel.tsx
@@ -18,12 +18,25 @@ type OptionProps = {
   children?: React.ReactNode
   leftClass?: string
   rightClass?: string
+  onClickLabel?: () => void
 }
 
-const Option = ({ label, keyCode, children, leftClass = '', rightClass = '' }: OptionProps) => (
+const Option = ({
+  label,
+  keyCode,
+  children,
+  leftClass = '',
+  rightClass = '',
+  onClickLabel,
+}: OptionProps) => (
   <div className="mb-4 flex items-center justify-between">
     <div className={cn('flex items-center', leftClass)}>
-      <div className="text-base font-semibold">{label}</div>
+      <div
+        className={cn('select-none text-base font-semibold', !!onClickLabel && 'cursor-default')}
+        onClick={onClickLabel}
+      >
+        {label}
+      </div>
       {!!keyCode && <kbd className="ml-2 text-[66%]">{keyCode}</kbd>}
     </div>
 
@@ -108,7 +121,7 @@ const ToggleOption = ({ label, keyCode, checked, disabled, onChange }: ToggleOpt
   }
 
   return (
-    <Option label={label} keyCode={keyCode}>
+    <Option label={label} keyCode={keyCode} onClickLabel={callback}>
       <input
         type="checkbox"
         className="h-4 w-4"
@@ -149,12 +162,10 @@ export const SettingsPanel = () => {
         isOpen={isOpen}
         onClickClose={toggleUIPanel}
       >
-        <div className="max-h-[70vh] overflow-auto px-6 pb-8 pt-3">
+        <div className="max-h-[70vh] overflow-auto px-8 pb-8 pt-10">
           {/* ************************************************************* */}
 
-          <div className="mb-5 text-center text-sm font-black uppercase tracking-widest">
-            Camera
-          </div>
+          <div className="mb-4 text-xs font-black uppercase opacity-60">Camera</div>
 
           <Option label="POV Camera (next)" keyCode="1" leftClass="col" />
           <Option label="POV Camera (prev)" keyCode="Shift + 1" leftClass="col" />
@@ -226,9 +237,7 @@ export const SettingsPanel = () => {
 
           {/* ************************************************************* */}
 
-          <div className="mb-5 mt-16 text-center text-sm font-black uppercase tracking-widest">
-            Scene
-          </div>
+          <div className="mb-4 mt-16 text-xs font-black uppercase opacity-60">Scene</div>
 
           <Option label="Material" keyCode="M">
             <div className="flex gap-1">
@@ -259,9 +268,7 @@ export const SettingsPanel = () => {
 
           {/* ************************************************************* */}
 
-          <div className="mb-5 mt-16 text-center text-sm font-black uppercase tracking-widest">
-            Players
-          </div>
+          <div className="mb-4 mt-16 text-xs font-black uppercase opacity-60">Players</div>
 
           <ToggleOption
             label="Player outlines (*expensive)"
@@ -304,9 +311,7 @@ export const SettingsPanel = () => {
 
           {/* ************************************************************* */}
 
-          <div className="mb-5 mt-16 text-center text-sm font-black uppercase tracking-widest">
-            Drawing
-          </div>
+          <div className="mb-4 mt-16 text-xs font-black uppercase opacity-60">Drawing</div>
 
           <Option label="Activate" keyCode="F" />
           <Option label="Clear" keyCode="C" />
@@ -340,9 +345,7 @@ export const SettingsPanel = () => {
 
           {/* ************************************************************* */}
 
-          <div className="mb-5 mt-16 text-center text-sm font-black uppercase tracking-widest">
-            Misc
-          </div>
+          <div className="mb-4 mt-16 text-xs font-black uppercase opacity-60">Misc</div>
 
           <ToggleOption
             label="Show FPS"

--- a/src/pages/ViewerPage.tsx
+++ b/src/pages/ViewerPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect } from 'react'
 import { useGLTF } from '@react-three/drei'
 import { motion } from 'framer-motion'
 
@@ -6,39 +6,22 @@ import { GlobalKeyHandler } from '@components/Misc/GlobalKeyHandler'
 import { DemoDropzone } from '@components/Misc/DemoDropzone'
 import { DemoDrawing } from '@components/Misc/DemoDrawing'
 import { DemoViewer } from '@components/DemoViewer'
+import {
+  POVCameraTipPanel,
+  SpectatorCameraTipPanel,
+  RtsCameraTipPanel,
+} from '@components/UI/CameraTipPanels'
 
 import { useStore, useInstance } from '@zus/store'
-import { usePointerLock } from '@utils/hooks'
 
 const ViewerPage = () => {
   const parser = useStore(state => state.parser)
   const parsedDemo = useInstance(state => state.parsedDemo)
   const loadedMap = useStore(state => state.scene.map)
-  const controlsMode = useStore(state => state.scene.controls.mode)
-
-  const { isPointerLocked } = usePointerLock()
 
   //
   // ─── LIFECYCLE ──────────────────────────────────────────────────────────────────
   //
-
-  // Little timer to force spectator tip to always display for at least a bit
-  // Would be cool to show a similar tip panel for all camera modes!
-  // TODO: maybe this can be a hook?
-  const [forceShow, setForceShow] = useState(false)
-
-  useEffect(() => {
-    let timeout: NodeJS.Timeout
-    if (controlsMode === 'spectator') {
-      setForceShow(true)
-      timeout = setTimeout(() => setForceShow(false), 2000)
-    }
-    return () => timeout && clearTimeout(timeout)
-  }, [controlsMode, isPointerLocked])
-
-  const showSpectatorFlyTip = useMemo(() => {
-    return controlsMode === 'spectator' && (forceShow || !isPointerLocked)
-  }, [forceShow, controlsMode, isPointerLocked])
 
   // Preload any assets here
   useEffect(() => {
@@ -71,85 +54,11 @@ const ViewerPage = () => {
         </motion.div>
       </div>
 
-      {/* Spectator camera fly tip overlay */}
-      <div className="ui-layer bottom-4 right-4 items-end justify-end overflow-hidden">
-        <motion.div
-          className="w-56 bg-pp-panel/80 px-4 py-2"
-          animate={showSpectatorFlyTip ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
-          transition={{ duration: 0.2 }}
-          initial={false}
-        >
-          <div className="d-flex mb-1 flex-row">
-            <strong>Spectator Camera</strong>
-            <div className="flex-fill" />
-            <div>
-              {isPointerLocked ? (
-                <motion.div
-                  key={`on`}
-                  initial={{ opacity: 0, y: -2 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3 }}
-                  style={{ color: '#4dd241' }}
-                >
-                  ON
-                </motion.div>
-              ) : (
-                <motion.div
-                  key={`idle`}
-                  initial={{ opacity: 0, y: -2 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3 }}
-                  style={{ color: '#fa9e21' }}
-                >
-                  IDLE
-                </motion.div>
-              )}
-            </div>
-          </div>
-
-          {!isPointerLocked && (
-            <motion.div>
-              <div className="d-flex flex-row">
-                <span>Activate</span>
-                <div className="flex-fill" />
-                <kbd>LMB</kbd>
-              </div>
-            </motion.div>
-          )}
-
-          {isPointerLocked && (
-            <motion.div>
-              <div className="d-flex mb-1 flex-row">
-                <span>Deactivate</span>
-                <div className="flex-fill" />
-                <kbd>RMB</kbd>
-              </div>
-
-              <div className="d-flex mb-1 flex-row">
-                <span>Movement</span>
-                <div className="flex-fill" />
-                <kbd className="ml-1">W</kbd>
-                <kbd className="ml-1">A</kbd>
-                <kbd className="ml-1">S</kbd>
-                <kbd className="ml-1">D</kbd>
-              </div>
-
-              <div className="d-flex mb-1 flex-row">
-                <span>Elevation</span>
-                <div className="flex-fill" />
-
-                <kbd className="ml-1">E</kbd>
-                <kbd className="ml-1">C</kbd>
-              </div>
-
-              <div className="d-flex flex-row">
-                <span>Boost</span>
-                <div className="flex-fill" />
-                <kbd>Shift</kbd>
-              </div>
-            </motion.div>
-          )}
-        </motion.div>
+      {/* Camera tip panels overlays */}
+      <div className="ui-layer bottom-0 right-0 items-end justify-end p-4">
+        <POVCameraTipPanel />
+        <SpectatorCameraTipPanel />
+        <RtsCameraTipPanel />
       </div>
 
       {/* Drawing overlay */}


### PR DESCRIPTION
Add panels that show up when changing camera modes (1, 2, 3)

So it's clearer to the user what is going on (and also has shortcut instructions)

<img width="284" alt="image" src="https://github.com/bryjch/dribble.tf/assets/9291779/a41c881c-2506-45d0-8ab2-cb3eb99c8095">


<img width="292" alt="image" src="https://github.com/bryjch/dribble.tf/assets/9291779/f6c71bee-12c4-42bb-89eb-c627016c8eea">
