### PR TITLE
fix: actor stuttering due to frameProgress on build bundle

### DIFF
--- a/src/components/Scene/Actors.tsx
+++ b/src/components/Scene/Actors.tsx
@@ -126,10 +126,10 @@ export const Actor = (props: ActorProps) => {
       return
     }
 
-    // we skip rendering for 0 because there are some race conditions between useFrame
+    // we skip rendering for 0 and 0.99 because there are some race conditions between useFrame
     // and requestAnimationFrame, which results in jerky rendering. This can be safely
     // done since the lerp smoothens out any potential "missed renders"
-    if (frameProgress > 0) {
+    if (frameProgress > 0 && frameProgress < 0.99) {
       // handle position lerping
       const lerpedPos = positionVec3.clone().lerp(positionNext, frameProgress)
       actorRef.current.position.set(lerpedPos.x, lerpedPos.y, lerpedPos.z)

--- a/src/pages/ViewerPage.tsx
+++ b/src/pages/ViewerPage.tsx
@@ -55,7 +55,7 @@ const ViewerPage = () => {
       </div>
 
       {/* Camera tip panels overlays */}
-      <div className="ui-layer bottom-0 right-0 items-end justify-end p-4">
+      <div className="ui-layer bottom-0 right-0 items-end justify-end overflow-hidden p-4">
         <POVCameraTipPanel />
         <SpectatorCameraTipPanel />
         <RtsCameraTipPanel />


### PR DESCRIPTION
For some reason the condition `(frameProgress > 0)` works fine in dev, but not in prod build.

Add an upper limit check to handle this: `(frameProgress > 0 && frameProgress < 0.99)`