### PR TITLE
feat: add bubble popups for last performed action

### DIFF
--- a/src/components/UI/EventHistoryText.tsx
+++ b/src/components/UI/EventHistoryText.tsx
@@ -1,0 +1,34 @@
+import {
+  AiFillFastForwardIcon,
+  AiFillStepForwardIcon,
+  IoMdPauseIcon,
+  IoMdPlayIcon,
+} from '@components/Misc/Icons'
+import { cn } from '@utils/styling'
+
+const iconClasses = 'w-5 h-5'
+
+export const EventHistoryText = ({ type }: { type: string }) => {
+  switch (type) {
+    case 'seekBackward':
+      return <AiFillFastForwardIcon className={cn(iconClasses, 'rotate-180')} />
+
+    case 'previousTick':
+      return <AiFillStepForwardIcon className={cn(iconClasses, 'rotate-180')} />
+
+    case 'play':
+      return <IoMdPlayIcon className={cn(iconClasses)} />
+
+    case 'pause':
+      return <IoMdPauseIcon className={cn(iconClasses)} />
+
+    case 'nextTick':
+      return <AiFillStepForwardIcon className={cn(iconClasses)} />
+
+    case 'seekForward':
+      return <AiFillFastForwardIcon className={cn(iconClasses)} />
+  }
+
+  // Probably a string, so pad the sides a bit
+  return <div className="px-2">{type}</div>
+}

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import * as Slider from '@radix-ui/react-slider'
+import { motion } from 'framer-motion'
 
 import {
   IoArrowForwardSharpIcon,
@@ -9,6 +10,7 @@ import {
   IoMdPauseIcon,
   IoMdPlayIcon,
 } from '@components/Misc/Icons'
+import { EventHistoryText } from './EventHistoryText'
 
 import { useInstance, useStore } from '@zus/store'
 import { goToTickAction, togglePlaybackAction, changePlaySpeedAction } from '@zus/actions'
@@ -64,6 +66,7 @@ const PlaybackAction = (props: PlaybackActionProps) => {
 export const PlaybackPanel = () => {
   const parsedDemo = useInstance(state => state.parsedDemo)
   const playback = useStore(state => state.playback)
+  const lastEventHistory = useStore(state => state.eventHistory)?.[0]
   const { playing, speed, tick, maxTicks } = playback
 
   const rounds = useMemo(() => {
@@ -108,7 +111,21 @@ export const PlaybackPanel = () => {
   }
 
   return (
-    <div className={cn('group relative m-4 max-w-full rounded-2xl px-6 py-2 transition-all')}>
+    <div className={cn('group relative m-4 max-w-full rounded-2xl px-6 py-2')}>
+      {lastEventHistory && (
+        <div className={cn('transition-all', playing ? '-mb-16 delay-700 group-hover:mb-0' : '')}>
+          <motion.div
+            className="pointer-events-none inline-block rounded-3xl bg-black/70 p-2"
+            initial={{ opacity: 1, y: 4 }}
+            animate={{ opacity: 0, y: 0 }}
+            transition={{ duration: 0.6 }}
+            key={`${lastEventHistory.type}.${lastEventHistory.timestamp}`}
+          >
+            <EventHistoryText type={lastEventHistory.type} />
+          </motion.div>
+        </div>
+      )}
+
       <div
         className={cn(
           'mt-4 flex items-center justify-center gap-6 rounded-full px-5 py-3 transition-all duration-500',

--- a/src/pages/ViewerPage.tsx
+++ b/src/pages/ViewerPage.tsx
@@ -45,12 +45,12 @@ const ViewerPage = () => {
       {/* Parsing demo overlay */}
       <div className="ui-layer top-20 items-start justify-center">
         <motion.div
-          className="inline-flex bg-pp-panel/80 px-4 py-2"
+          className="inline-flex rounded-lg bg-pp-panel/80 px-5 py-2"
           animate={parser.status === 'loading' ? { opacity: 1, y: 0 } : { opacity: 0, y: -20 }}
           transition={{ duration: 0.2 }}
           initial={false}
         >
-          <div>Parsing demo... {parser.progress}%</div>
+          <div>Parsing demo ... {parser.progress}%</div>
         </motion.div>
       </div>
 

--- a/src/zustand/actions.ts
+++ b/src/zustand/actions.ts
@@ -289,18 +289,22 @@ export const playbackJumpAction = async (direction: string) => {
     switch (direction) {
       case 'seekBackward':
         goToTickAction(tick - PLAYBACK_JUMP_TICK_INCREMENT)
+        addEventHistoryAction('seekBackward')
         break
 
       case 'seekForward':
         goToTickAction(tick + PLAYBACK_JUMP_TICK_INCREMENT)
+        addEventHistoryAction('seekForward')
         break
 
       case 'previousTick':
         goToTickAction(tick - 1)
+        addEventHistoryAction('previousTick')
         break
 
       case 'nextTick':
         goToTickAction(tick + 1)
+        addEventHistoryAction('nextTick')
         break
 
       default:
@@ -323,6 +327,8 @@ export const togglePlaybackAction = async (playing = undefined) => {
     }
 
     dispatch({ type: 'TOGGLE_PLAYBACK', payload: isPlaying })
+
+    addEventHistoryAction(isPlaying ? 'play' : 'pause')
   } catch (error) {
     console.error(error)
   }
@@ -343,6 +349,7 @@ export const changePlaySpeedAction = async (speed: 'faster' | 'slower' | number)
           type: 'CHANGE_PLAY_SPEED',
           payload: PLAYBACK_SPEED_OPTIONS[prevIndex].value,
         })
+        addEventHistoryAction(PLAYBACK_SPEED_OPTIONS[prevIndex].value + '× speed')
         break
 
       case 'slower':
@@ -350,6 +357,8 @@ export const changePlaySpeedAction = async (speed: 'faster' | 'slower' | number)
           type: 'CHANGE_PLAY_SPEED',
           payload: PLAYBACK_SPEED_OPTIONS[nextIndex].value,
         })
+        addEventHistoryAction(PLAYBACK_SPEED_OPTIONS[nextIndex].value + '× speed')
+
         break
 
       default:
@@ -450,6 +459,16 @@ export const toggleUIDrawingAction = async (active?: boolean) => {
         drawingCanvas?.clear()
       }
     }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+// ─── EVENT HISTORY ───────────────────────────────────────────────────────────
+
+export const addEventHistoryAction = async (type: string, value?: string) => {
+  try {
+    dispatch({ type: 'ADD_EVENT_HISTORY', payload: { type, value, timestamp: Date.now() } })
   } catch (error) {
     console.error(error)
   }

--- a/src/zustand/reducer.ts
+++ b/src/zustand/reducer.ts
@@ -141,6 +141,16 @@ const reducers = (state: StoreState, action: StoreAction) => {
         drawing: { ...state.drawing, enabled: false },
       }
 
+    //
+    // ─── EVENT HISTORY ───────────────────────────────────────────────
+    //
+
+    case 'ADD_EVENT_HISTORY':
+      return {
+        ...state,
+        eventHistory: [action.payload, ...state.eventHistory].slice(0, 10),
+      }
+
     default:
       return state
   }

--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -131,6 +131,11 @@ export type StoreState = {
   ui: {
     activePanels: UIPanelType[]
   }
+  eventHistory: {
+    type: string
+    value?: string
+    timestamp: number
+  }[]
 }
 
 export const initialState: StoreState = {
@@ -202,6 +207,8 @@ export const initialState: StoreState = {
   ui: {
     activePanels: [UIPanelType.ABOUT],
   },
+
+  eventHistory: [],
 }
 
 export type StoreAction = {


### PR DESCRIPTION
Little bubbles that pop up briefly when performing any playback action.

Useful as visual feedback for successful actions being made (especially when PlaybackPanel is hidden).

<img width="343" alt="image" src="https://github.com/user-attachments/assets/4c46271a-c820-4687-90ce-4e7cadf5e6ff">

<img width="376" alt="image" src="https://github.com/user-attachments/assets/3744a447-8db2-456d-ba69-1a5c698243d1">
