### PR TITLE
feat: improve mobile usability

### DIFF
--- a/src/components/DemoViewer.tsx
+++ b/src/components/DemoViewer.tsx
@@ -32,7 +32,7 @@ import { FocusedPlayer } from '@components/UI/FocusedPlayer'
 
 // Actions & utils
 import { useStore, getState, useInstance } from '@zus/store'
-import { goToTickAction } from '@zus/actions'
+import { forceShowPanelAction, goToTickAction } from '@zus/actions'
 import { ActorProps } from './Scene/Actors'
 
 //
@@ -170,6 +170,7 @@ class DemoViewer extends Component<DemoViewerProps> {
   // Timing variables for animation loop
   elapsedTime = 0
   lastTimestamp = 0
+  lastTouchPos = { x: 0, y: 0 }
 
   state = {
     playback: getState().playback,
@@ -235,6 +236,19 @@ class DemoViewer extends Component<DemoViewerProps> {
     requestAnimationFrame(this.animate)
   }
 
+  onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    this.lastTouchPos = { x: event.clientX, y: event.clientY }
+  }
+
+  onPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (
+      Math.abs(event.clientX - this.lastTouchPos.x) < 10 &&
+      Math.abs(event.clientY - this.lastTouchPos.y) < 10
+    ) {
+      forceShowPanelAction()
+    }
+  }
+
   //
   // ─── RENDER ─────────────────────────────────────────────────────────────────────
   //
@@ -273,6 +287,8 @@ class DemoViewer extends Component<DemoViewerProps> {
           id="main-canvas"
           gl={{ alpha: true }}
           onContextMenu={e => e.preventDefault()}
+          onPointerDown={this.onPointerDown}
+          onPointerUp={this.onPointerUp}
         >
           {/* Base scene elements */}
 
@@ -344,7 +360,7 @@ class DemoViewer extends Component<DemoViewerProps> {
             <SettingsPanel />
           </div>
 
-          <div className="ui-layer justift-start m-4 mt-[calc(1.75rem+33px)] items-start">
+          <div className="ui-layer justift-start m-4 mt-16 items-start">
             <AboutPanel />
           </div>
         </div>

--- a/src/components/UI/AboutPanel.tsx
+++ b/src/components/UI/AboutPanel.tsx
@@ -67,13 +67,8 @@ export const AboutPanel = () => {
         <TiInfoLargeIcon />
       </TogglePanelButton>
 
-      <TogglePanel
-        className="w-[380px]"
-        showCloseButton
-        isOpen={isOpen}
-        onClickClose={toggleUIPanel}
-      >
-        <div className="px-8 pb-12 pt-8">
+      <TogglePanel showCloseButton isOpen={isOpen} onClickClose={toggleUIPanel}>
+        <div className="max-h-[75vh] overflow-auto px-8 pb-12 pt-8">
           <div className="flex items-center">
             {/* Logo */}
 

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import * as Slider from '@radix-ui/react-slider'
 import { motion } from 'framer-motion'
@@ -34,13 +34,33 @@ interface PlaybackActionProps {
   content: React.ReactNode
   icon: React.ReactNode
   onClick?: () => void
+  /**
+   * Radix doesn't display tooltips on mobile, so we need a way to force show it
+   * https://github.com/radix-ui/primitives/issues/1573
+   */
+  mobileTooltipBypass?: boolean
 }
 
 const PlaybackAction = (props: PlaybackActionProps) => {
+  const [open, setOpen] = useState(false)
+
+  let bypassProps = { root: {}, trigger: {} }
+
+  if (props.mobileTooltipBypass) {
+    bypassProps = {
+      root: { open, onOpenChange: setOpen },
+      trigger: {
+        onClick: () => setOpen(prevOpen => !prevOpen),
+        onFocus: () => setTimeout(() => setOpen(true), 0),
+        onBlur: () => setOpen(false),
+      },
+    }
+  }
+
   return (
     <Tooltip.Provider delayDuration={0}>
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
+      <Tooltip.Root {...bypassProps.root}>
+        <Tooltip.Trigger asChild {...bypassProps.trigger}>
           <div
             className={cn(
               'cursor-pointer opacity-80',
@@ -136,6 +156,7 @@ export const PlaybackPanel = () => {
         {/* Jump to tick action */}
 
         <PlaybackAction
+          mobileTooltipBypass
           icon={
             <div className="-mr-1 flex min-w-11 select-none flex-col items-center text-center">
               <div className="text-xs leading-none">TICK</div>
@@ -246,6 +267,7 @@ export const PlaybackPanel = () => {
         {/* Change play speed action */}
 
         <PlaybackAction
+          mobileTooltipBypass
           icon={
             <div className="select-none rounded-3xl bg-white/90 px-2 text-sm text-black">
               {speed}×

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -67,7 +67,7 @@ export const PlaybackPanel = () => {
   const parsedDemo = useInstance(state => state.parsedDemo)
   const playback = useStore(state => state.playback)
   const lastEventHistory = useStore(state => state.eventHistory)?.[0]
-  const { playing, speed, tick, maxTicks } = playback
+  const { playing, speed, tick, maxTicks, forceShowPanel } = playback
 
   const rounds = useMemo(() => {
     const result = [
@@ -129,7 +129,7 @@ export const PlaybackPanel = () => {
       <div
         className={cn(
           'mt-4 flex items-center justify-center gap-6 rounded-full px-5 py-3 transition-all duration-500',
-          playing ? 'scale-90 opacity-0 delay-700' : 'bg-black/70 delay-0',
+          playing && !forceShowPanel ? 'scale-90 opacity-0 delay-700' : 'bg-black/70 delay-0',
           'group-hover:scale-100 group-hover:bg-black/70 group-hover:opacity-100 group-hover:delay-0'
         )}
       >

--- a/src/components/UI/SettingsPanel.tsx
+++ b/src/components/UI/SettingsPanel.tsx
@@ -157,12 +157,12 @@ export const SettingsPanel = () => {
       </TogglePanelButton>
 
       <TogglePanel
-        className="w-[460px]"
+        className="w-[clamp(100px,460px,80vw)]"
         showCloseButton
         isOpen={isOpen}
         onClickClose={toggleUIPanel}
       >
-        <div className="max-h-[70vh] overflow-auto px-8 pb-8 pt-10">
+        <div className="max-h-[90vh] overflow-auto px-8 pb-8 pt-10">
           {/* ************************************************************* */}
 
           <div className="mb-4 text-xs font-black uppercase opacity-60">Camera</div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -61,8 +61,15 @@
 html {
   background-color: var(--background-primary);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 1.5vw;
+  font-size: clamp(8px, 1.5vw, 14px);
   font-family: 'Source Sans Pro', sans-serif;
+}
+
+@media screen and (min-width: 1024px) {
+  html {
+    font-size: 14px;
+  }
 }
 
 pre,

--- a/src/pages/ViewerPage.tsx
+++ b/src/pages/ViewerPage.tsx
@@ -43,7 +43,7 @@ const ViewerPage = () => {
       <DemoViewer demo={parsedDemo} map={loadedMap} />
 
       {/* Parsing demo overlay */}
-      <div className="ui-layer top-20 items-start justify-center">
+      <div className="ui-layer pointer-events-none top-20 items-start justify-center">
         <motion.div
           className="inline-flex rounded-lg bg-pp-panel/80 px-5 py-2"
           animate={parser.status === 'loading' ? { opacity: 1, y: 0 } : { opacity: 0, y: -20 }}
@@ -55,7 +55,7 @@ const ViewerPage = () => {
       </div>
 
       {/* Camera tip panels overlays */}
-      <div className="ui-layer bottom-0 right-0 items-end justify-end overflow-hidden p-4">
+      <div className="ui-layer pointer-events-none bottom-0 right-0 items-end justify-end overflow-hidden p-4 [&>div]:pointer-events-none">
         <POVCameraTipPanel />
         <SpectatorCameraTipPanel />
         <RtsCameraTipPanel />

--- a/src/zustand/actions.ts
+++ b/src/zustand/actions.ts
@@ -370,6 +370,20 @@ export const changePlaySpeedAction = async (speed: 'faster' | 'slower' | number)
   }
 }
 
+export const forceShowPanelAction = async (forceShowPanel?: boolean) => {
+  try {
+    if (forceShowPanel === undefined) {
+      forceShowPanel = !getState().playback.forceShowPanel
+    }
+
+    dispatch({ type: 'FORCE_SHOW_PANEL', payload: forceShowPanel })
+
+    setTimeout(() => dispatch({ type: 'FORCE_SHOW_PANEL', payload: false }), 1500)
+  } catch (error) {
+    console.error(error)
+  }
+}
+
 //
 // ─── SETTINGS ───────────────────────────────────────────────────────────────────
 //

--- a/src/zustand/reducer.ts
+++ b/src/zustand/reducer.ts
@@ -87,6 +87,9 @@ const reducers = (state: StoreState, action: StoreAction) => {
     case 'CHANGE_PLAY_SPEED':
       return { ...state, playback: { ...state.playback, speed: action.payload } }
 
+    case 'FORCE_SHOW_PANEL':
+      return { ...state, playback: { ...state.playback, forceShowPanel: action.payload } }
+
     //
     // ─── SETTINGS ────────────────────────────────────────────────────
     //

--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -89,6 +89,7 @@ export type StoreState = {
     speed: number
     tick: number
     maxTicks: number
+    forceShowPanel: boolean
   }
   drawing: {
     enabled: boolean
@@ -159,6 +160,7 @@ export const initialState: StoreState = {
     speed: 1,
     tick: 1,
     maxTicks: 3000,
+    forceShowPanel: false,
   },
 
   drawing: {


### PR DESCRIPTION
The quickest way to make mobile "usable" - just make the root font size smaller (in this scale, scale with viewport width).

In the future some more mobile specific UI would be great, but at least this isn't totally broken like before

<img width="665" alt="image" src="https://github.com/user-attachments/assets/e765ebf3-e839-4285-91c5-5e5647fa1c79">
