### PR TITLE
add event history text for material change action

### DIFF
--- a/src/components/UI/EventHistoryText.tsx
+++ b/src/components/UI/EventHistoryText.tsx
@@ -8,7 +8,7 @@ import { cn } from '@utils/styling'
 
 const iconClasses = 'w-5 h-5'
 
-export const EventHistoryText = ({ type }: { type: string }) => {
+export const EventHistoryText = ({ type, value }: { type: string; value?: any }) => {
   switch (type) {
     case 'seekBackward':
       return <AiFillFastForwardIcon className={cn(iconClasses, 'rotate-180')} />
@@ -27,8 +27,15 @@ export const EventHistoryText = ({ type }: { type: string }) => {
 
     case 'seekForward':
       return <AiFillFastForwardIcon className={cn(iconClasses)} />
+
+    case 'changeMaterial':
+      return (
+        <div className="px-2">
+          Material: <span className="font-bold">{value}</span>
+        </div>
+      )
   }
 
   // Probably a string, so pad the sides a bit
-  return <div className="px-2">{type}</div>
+  return <div className="px-2">{value}</div>
 }

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -141,7 +141,7 @@ export const PlaybackPanel = () => {
             transition={{ duration: 0.6 }}
             key={`${lastEventHistory.type}.${lastEventHistory.timestamp}`}
           >
-            <EventHistoryText type={lastEventHistory.type} />
+            <EventHistoryText {...lastEventHistory} />
           </motion.div>
         </div>
       )}

--- a/src/zustand/actions.ts
+++ b/src/zustand/actions.ts
@@ -260,8 +260,10 @@ export const changeSceneModeAction = async (mode: SceneMode | 'next') => {
 
   if (mode) {
     await updateSettingsOptionAction('scene.mode', mode)
+    addEventHistoryAction('changeMaterial', mode)
   }
 }
+
 //
 // ─── PLAYBACK ───────────────────────────────────────────────────────────────────
 //
@@ -349,7 +351,10 @@ export const changePlaySpeedAction = async (speed: 'faster' | 'slower' | number)
           type: 'CHANGE_PLAY_SPEED',
           payload: PLAYBACK_SPEED_OPTIONS[prevIndex].value,
         })
-        addEventHistoryAction(PLAYBACK_SPEED_OPTIONS[prevIndex].value + '× speed')
+        addEventHistoryAction(
+          'changePlaySpeed',
+          PLAYBACK_SPEED_OPTIONS[prevIndex].value + '× speed'
+        )
         break
 
       case 'slower':
@@ -357,7 +362,10 @@ export const changePlaySpeedAction = async (speed: 'faster' | 'slower' | number)
           type: 'CHANGE_PLAY_SPEED',
           payload: PLAYBACK_SPEED_OPTIONS[nextIndex].value,
         })
-        addEventHistoryAction(PLAYBACK_SPEED_OPTIONS[nextIndex].value + '× speed')
+        addEventHistoryAction(
+          'changePlaySpeed',
+          PLAYBACK_SPEED_OPTIONS[nextIndex].value + '× speed'
+        )
 
         break
 


### PR DESCRIPTION
just make it so pressing `M` will show `material: wireframe` so user knows their action is doing something