### PR TITLE
feat: default untextured on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postprocessing": "^6.35.3",
     "react": "^18.2.0",
     "react-canvas-draw": "^1.1.1",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
     "react-dropzone": "^11.2.4",
     "three": "^0.163.0",

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -148,7 +148,7 @@ export const PlaybackPanel = () => {
 
       <div
         className={cn(
-          'mt-4 flex items-center justify-center gap-6 rounded-full px-5 py-3 transition-all duration-500',
+          'z-20 mt-4 flex items-center justify-center gap-6 rounded-full px-5 py-3 transition-all duration-500',
           playing && !forceShowPanel ? 'scale-90 opacity-0 delay-700' : 'bg-black/70 delay-0',
           'group-hover:scale-100 group-hover:bg-black/70 group-hover:opacity-100 group-hover:delay-0'
         )}

--- a/src/zustand/actions.ts
+++ b/src/zustand/actions.ts
@@ -10,7 +10,8 @@ import { getSceneActors, parseMapBoundaries } from '@utils/scene'
 import { CLASS_ORDER_MAP } from '@constants/mappings'
 import { ControlsMode, Download, SceneMode, UIPanelType } from '@constants/types'
 
-import { dispatch, getState, initialState, useInstance } from './store'
+import { dispatch, getState, initialState, StoreState, useInstance } from './store'
+import { isMobile } from 'react-device-detect'
 
 //
 // ─── PARSER ─────────────────────────────────────────────────────────────────────
@@ -399,7 +400,13 @@ export const forceShowPanelAction = async (forceShowPanel?: boolean) => {
 export const loadSettingsAction = async () => {
   try {
     const defaultSettings = getState().settings
-    const settings = await localForage.getItem('settings')
+    const settings = await localForage.getItem<StoreState['settings']>('settings')
+
+    // Always default to untextured on mobile devices because textured scene takes up
+    // a lot of memory - and risk the device's browser crashing.
+    if (settings && isMobile) {
+      settings.scene.mode = SceneMode.UNTEXTURED
+    }
 
     dispatch({ type: 'LOAD_SETTINGS', payload: { settings: merge(defaultSettings, settings) } })
   } catch (error) {

--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { redux } from 'zustand/middleware'
 import CanvasDraw from 'react-canvas-draw'
+import { isMobile } from 'react-device-detect'
 import * as THREE from 'three'
 
 import { AsyncParser } from '@components/Analyse/Data/AsyncParser'
@@ -171,7 +172,7 @@ export const initialState: StoreState = {
 
   settings: {
     scene: {
-      mode: SceneMode.TEXTURED,
+      mode: isMobile ? SceneMode.UNTEXTURED : SceneMode.TEXTURED,
       interpolateFrames: true,
     },
     camera: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,6 +2726,13 @@ react-composer@^5.0.3:
   dependencies:
     prop-types "^15.6.0"
 
+react-device-detect@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.2.3.tgz#97a7ae767cdd004e7c3578260f48cf70c036e7ca"
+  integrity sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==
+  dependencies:
+    ua-parser-js "^1.0.33"
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -3265,6 +3272,11 @@ typescript@^5.4.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
   integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
+
+ua-parser-js@^1.0.33:
+  version "1.0.40"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.40.tgz#ac6aff4fd8ea3e794a6aa743ec9c2fc29e75b675"
+  integrity sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==
 
 update-browserslist-db@^1.0.13:
   version "1.0.13"


### PR DESCRIPTION
Textured scenes are very memory intensive, which can cause mobile devices to crash.

Should always enforce/override to `UNTEXTURED`:
- on first load
- subsequent settings loads