### PR TITLE
feat: add projectile trails

### DIFF
--- a/specs/trails-and-explosions.md
+++ b/specs/trails-and-explosions.md
@@ -1,0 +1,169 @@
+Projectile Trails & Explosion Effects
+
+Context
+
+The demo viewer currently renders projectiles (rockets, stickybombs, pipebombs, healing bolts)
+as plain 3D models with no visual effects. We want to add:
+1. Trails behind rockets, stickybombs, and arrows as they travel
+2. Explosion effects when projectiles detonate
+
+The tf2jump/dev branch has a trail implementation using @react-three/drei's Trail component
+(MeshLine-based), but only in POV mode and with no explosion effects. We'll adapt that approach
+for all camera modes and add explosion effects.
+
+Key Design Decisions
+
+- Trails in all camera modes, styled differently per mode:
+  - POV mode: Bold trails matching tf2jump/dev style (screen-space width, additive blending, no
+depth test)
+  - 3rd-person modes (RTS/Spectator): Subtler, thinner trails with world-space width and
+standard blending so they don't overpower the overview
+- Trail styling: Rockets get a smoke-to-yellow gradient trail; stickybombs get team-colored
+trails; pipebombs get shorter team-colored trails; healing bolts get a yellow trail
+- Explosion detection: Track which projectile entityIds exist each tick. When one disappears,
+spawn an explosion effect at its last known position. This is the only feasible approach
+without parser changes.
+- Explosion visual: Simple expanding/fading translucent sphere with additive blending —
+lightweight, no textures needed, fits the clean aesthetic
+- Port enhanced interpolation from tf2jump/dev (positionPrev, positionNext2, smoothingAlpha)
+for smoother trail rendering
+- Skip spawnTick for now — it requires WASM parser changes. Can be added later for spawn delay
+polish.
+
+Files to Modify
+
+1. src/components/Scene/Projectiles.tsx — Main changes: add Trail wrapping, explosion tracking,
+explosion component
+2. src/components/DemoViewer.tsx — Pass additional tick data (prev/next2) and
+tick/intervalPerTick props
+3. src/components/Analyse/Data/ProjectileCache.ts — No changes needed (spawnTick deferred)
+
+Implementation Steps
+
+Step 1: Update DemoViewer to provide richer projectile data
+
+File: src/components/DemoViewer.tsx
+
+- Expand InterpolatedProjectile building to fetch prev tick and next2 tick projectile data
+(matching tf2jump/dev pattern)
+- Add MAX_PROJECTILES_FOR_HIGH_QUALITY_INTERPOLATION = 16 guard
+- Pass tick and intervalPerTick props to <Projectiles> component
+- Rename interpTick → renderTick for clarity (matching tf2jump/dev)
+
+Changes to the projectile building block (~line 313-326):
+// Fetch additional ticks for smoother interpolation
+const useHighQualityProjectileInterpolation =
+  projectilesCurrentTick.length <= MAX_PROJECTILES_FOR_HIGH_QUALITY_INTERPOLATION
+const projectilesPrevTick = useHighQualityProjectileInterpolation
+  ? demo.getProjectilesAtTick(Math.max(renderTick - 1, 1))
+  : []
+const projectilesNext2Tick = useHighQualityProjectileInterpolation
+  ? demo.getProjectilesAtTick(renderTick + 2)
+  : []
+
+// Build maps and include positionPrev/positionNext2
+projectilesThisTick = projectilesCurrentTick.map(projectile => ({
+  ...projectile,
+  positionPrev: prevProjectile?.position ?? projectile.position,
+  positionNext: nextProjectile?.position ?? projectile.position,
+  positionNext2: next2Projectile?.position ?? nextProjectile?.position ?? projectile.position,
+  rotationNext: nextProjectile?.rotation ?? projectile.rotation,
+}))
+
+Render change:
+<Projectiles
+  projectiles={projectilesThisTick}
+  tick={renderTick}
+  intervalPerTick={demo?.intervalPerTick ?? 0.015}
+/>
+
+Step 2: Rewrite Projectiles.tsx with trails and enhanced interpolation
+
+File: src/components/Scene/Projectiles.tsx
+
+Port from tf2jump/dev with these adaptations:
+
+a) Update interfaces and imports:
+- Import Trail from @react-three/drei
+- Import useStore for accessing settings/controls state
+- InterpolatedProjectile adds positionPrev, positionNext2 fields
+- ProjectilesProps adds tick and intervalPerTick
+- BaseProjectileProps adds renderTick and intervalPerTick
+
+b) Add interpolation helpers (from tf2jump/dev):
+- interpolatePosition() — lerp with teleport detection
+- smoothingAlpha() — exponential decay for frame-rate-independent smoothing
+- Constants: PROJECTILE_POSITION_SMOOTH_SECONDS, PROJECTILE_ROTATION_SMOOTH_SECONDS
+
+c) Add trail material functions (from tf2jump/dev):
+- applyRocketTrailMaterial(trailMesh) — gradient grey→yellow, additive blending, no depth test,
+screen-space width
+- applyStickyTrailMaterial(trailMesh, color) — team-colored, additive blending
+
+d) Wrap each projectile type with <Trail>:
+- RocketProjectile: Trail with width=100, length=24, gradient material
+- StickybombProjectile: Trail with width=80, length=20, team-colored
+- PipebombProjectile: Trail with width=60, length=16, team-colored
+- HealingBoltProjectile: Trail with width=40, length=12, yellow
+- Trails render in all camera modes, but adapt style based on mode:
+  - POV: bold (screen-space width via sizeAttenuation=0, additive blending, depthTest=false) —
+matches tf2jump/dev
+  - 3rd-person: subtle (world-space width via default sizeAttenuation, normal blending,
+depthTest=true, lower opacity ~0.5)
+
+e) Update useFrame loops to use the enhanced interpolation with smoothingAlpha and
+delta-time-based blending.
+
+Step 3: Add explosion effect system
+
+File: src/components/Scene/Projectiles.tsx
+
+a) Track projectile lifecycle in Projectiles component:
+// Track previous tick's projectile IDs to detect disappearances
+const prevProjectileIds = useRef<Map<number, { position: Vector; type: string; teamNumber:
+number }>>(new Map())
+const [explosions, setExplosions] = useState<Explosion[]>([])
+
+// Each render: compare current projectile set to previous
+// Missing entityIds → projectile detonated → spawn explosion at last position
+
+b) Explosion data structure:
+interface Explosion {
+  id: number
+  position: THREE.Vector3
+  type: string       // rocket, pipebomb, stickybomb
+  teamNumber: number
+  startTime: number  // performance.now() when created
+}
+
+c) ExplosionEffect component:
+- Renders a <Sphere> mesh with meshBasicMaterial
+- Additive blending, transparent, no depth write
+- Color based on projectile type/team (orange-red for rockets, team-colored for stickies/pipes)
+- Animates over ~0.3-0.5 seconds: scale expands from 0 → ~80 HU radius, opacity fades from 0.6
+→ 0
+- Self-removes after animation completes
+- Uses useFrame for animation
+
+d) Render explosions alongside projectiles:
+<group name="projectiles">
+  {projectiles.map(p => <Projectile ... />)}
+  {explosions.map(e => <ExplosionEffect key={e.id} ... />)}
+</group>
+
+Step 4: Add trail fallback / model normalization
+
+Port normalizeProjectileModelKey and ProjectileFallback from tf2jump/dev for more robust model
+loading (handles missing team gracefully with a colored sphere fallback).
+
+Verification
+
+1. Load a demo with rockets being fired — verify trails appear behind rockets with smoke→yellow
+gradient
+2. Load a demo with stickybombs — verify team-colored trails appear
+3. Watch projectiles detonate — verify brief expanding sphere explosion appears at detonation
+point
+4. Switch between RTS/Spectator/POV camera modes — verify trails render in all modes
+5. Scrub timeline back and forth — verify no trail/explosion artifacts persist incorrectly
+6. Test with a demo containing many simultaneous projectiles — verify performance is acceptable
+7. Run npm run build to confirm no type errors

--- a/src/components/Scene/Projectiles.tsx
+++ b/src/components/Scene/Projectiles.tsx
@@ -1,22 +1,75 @@
-import { useRef, useState, useEffect, Suspense } from 'react'
+import { useRef, useState, useEffect, useMemo, useCallback, Suspense } from 'react'
 
 import * as THREE from 'three'
 import { useFrame } from '@react-three/fiber'
-import { Sphere, useGLTF } from '@react-three/drei'
+import { Sphere, Trail, useGLTF } from '@react-three/drei'
 import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js'
 
 import { CachedProjectile } from '@components/Analyse/Data/ProjectileCache'
-import { useInstance } from '@zus/store'
+import { useStore, useInstance } from '@zus/store'
 
 import { TEAM_MAP } from '@constants/mappings'
 import { objCoordsToVector3, eulerizeVector } from '@utils/geometry'
 import { getAsset } from '@utils/misc'
 
+//
+// ─── CONSTANTS ──────────────────────────────────────────────────────────────────
+//
+
 const TELEPORT_LERP_DISTANCE = 4096
+const PROJECTILE_POSITION_SMOOTH_SECONDS = 0.05
+const PROJECTILE_ROTATION_SMOOTH_SECONDS = 0.08
+const EXPLOSION_DURATION_MS = 400
+const EXPLOSION_MAX_RADIUS = 50
+const EXPLOSION_MAX_OPACITY = 0.4
+
+// Team colors for trails/explosions
+const TEAM_COLORS: Record<string, string> = {
+  red: '#cf4a2e',
+  blue: '#5885a2',
+}
+
+const TRAIL_FALLBACK_COLOR = '#999999'
+const ROCKET_TRAIL_COLOR = '#999999'
+const DEFAULT_EXPLOSION_COLOR = '#cccccc'
+
+//
+// ─── INTERPOLATION HELPERS ──────────────────────────────────────────────────────
+//
+
+function smoothingAlpha(smoothSeconds: number, delta: number): number {
+  return 1 - Math.exp(-delta / Math.max(smoothSeconds, 0.0001))
+}
+
+function interpolatePosition(
+  current: THREE.Vector3,
+  next: THREE.Vector3,
+  progress: number,
+  out: THREE.Vector3
+): THREE.Vector3 {
+  if (current.distanceTo(next) > TELEPORT_LERP_DISTANCE) {
+    return out.copy(current)
+  }
+  return out.copy(current).lerp(next, progress)
+}
 
 //
 // ─── PROJECTILE MODEL ───────────────────────────────────────────────────────────
 //
+
+const PROJECTILE_MODEL_KEYS: Record<string, string[]> = {
+  rocket: ['rocket_shared'],
+  pipebomb: ['pipebomb_red', 'pipebomb_blue'],
+  stickybomb: ['stickybomb_red', 'stickybomb_blue'],
+}
+
+function normalizeProjectileModelKey(type: string, team: string): string {
+  const key = `${type}_${team}`
+  const validKeys = PROJECTILE_MODEL_KEYS[type]
+  if (validKeys && validKeys.includes(key)) return key
+  if (validKeys && validKeys.length > 0) return validKeys[0]
+  return key
+}
 
 export interface ProjectileModelProps {
   type: 'rocket' | 'pipebomb' | 'stickybomb'
@@ -27,7 +80,8 @@ export interface ProjectileModelProps {
 export const ProjectileModel = (props: ProjectileModelProps) => {
   const [cachedScene, setCachedScene] = useState<any>()
 
-  const model = getAsset(`/models/projectiles/${props.type}_${props.team}.glb`)
+  const modelKey = normalizeProjectileModelKey(props.type, props.team)
+  const model = getAsset(`/models/projectiles/${modelKey}.glb`)
   const gltf = useGLTF(model, true)
 
   if (!cachedScene) {
@@ -38,13 +92,83 @@ export const ProjectileModel = (props: ProjectileModelProps) => {
   return <group>{cachedScene && <primitive object={cachedScene} />}</group>
 }
 
+const ProjectileFallback = ({ color = TRAIL_FALLBACK_COLOR }: { color?: string }) => (
+  <Sphere args={[4]}>
+    <meshBasicMaterial color={color} />
+  </Sphere>
+)
+
 //
 // ─── INTERPOLATED PROJECTILE ────────────────────────────────────────────────────
 //
 
 export interface InterpolatedProjectile extends CachedProjectile {
+  positionPrev: CachedProjectile['position']
   positionNext: CachedProjectile['position']
+  positionNext2: CachedProjectile['position']
   rotationNext: CachedProjectile['rotation']
+}
+
+//
+// ─── EXPLOSION EFFECT ───────────────────────────────────────────────────────────
+//
+
+interface Explosion {
+  id: number
+  position: THREE.Vector3
+  type: string
+  teamNumber: number
+  startTime: number
+}
+
+const ExplosionEffect = ({
+  explosion,
+  onComplete,
+}: {
+  explosion: Explosion
+  onComplete: (id: number) => void
+}) => {
+  const meshRef = useRef<THREE.Mesh>(null)
+  const materialRef = useRef<THREE.MeshBasicMaterial>(null)
+
+  const color = useMemo(() => {
+    return DEFAULT_EXPLOSION_COLOR;
+    // if (explosion.type === 'rocket') return DEFAULT_EXPLOSION_COLOR
+    // const team = TEAM_MAP[explosion.teamNumber]
+    // return TEAM_COLORS[team] ?? DEFAULT_EXPLOSION_COLOR
+  }, [explosion.type, explosion.teamNumber])
+
+  useFrame(() => {
+    if (!meshRef.current || !materialRef.current) return
+
+    const elapsed = performance.now() - explosion.startTime
+    const progress = Math.min(elapsed / EXPLOSION_DURATION_MS, 1)
+
+    // Expand: ease-out curve
+    const scale = EXPLOSION_MAX_RADIUS * (1 - Math.pow(1 - progress, 3))
+    meshRef.current.scale.setScalar(scale)
+
+    // Fade out
+    materialRef.current.opacity = EXPLOSION_MAX_OPACITY * (1 - progress)
+
+    if (progress >= 1) {
+      onComplete(explosion.id)
+    }
+  })
+
+  return (
+    <mesh ref={meshRef} position={explosion.position}>
+      <sphereGeometry args={[1, 12, 8]} />
+      <meshBasicMaterial
+        ref={materialRef}
+        color={color}
+        transparent
+        blending={THREE.AdditiveBlending}
+        depthWrite={false}
+        opacity={EXPLOSION_MAX_OPACITY}
+      />
+    </mesh>
+  )
 }
 
 //
@@ -53,10 +177,77 @@ export interface InterpolatedProjectile extends CachedProjectile {
 
 export interface ProjectilesProps {
   projectiles: InterpolatedProjectile[]
+  tick: number
+  intervalPerTick: number
 }
 
+let nextExplosionId = 0
+
 export const Projectiles = (props: ProjectilesProps) => {
-  const { projectiles = [] } = props
+  const { projectiles = [], tick, intervalPerTick } = props
+
+  // Track previous tick's projectiles for explosion detection
+  const prevProjectileIds = useRef<
+    Map<number, { position: THREE.Vector3; type: string; teamNumber: number }>
+  >(new Map())
+  const prevTick = useRef<number>(tick)
+  const [explosions, setExplosions] = useState<Explosion[]>([])
+
+  // Detect projectile disappearances → spawn explosions
+  useEffect(() => {
+    const currentIds = new Set(projectiles.map(p => p.entityId))
+    const prev = prevProjectileIds.current
+
+    // Only detect explosions when advancing forward by 1 tick (not scrubbing)
+    const isForwardStep = tick === prevTick.current + 1
+
+    if (isForwardStep && prev.size > 0) {
+      const newExplosions: Explosion[] = []
+
+      prev.forEach((data, entityId) => {
+        if (!currentIds.has(entityId)) {
+          // Only explode rockets, stickybombs, and pipebombs (not healing bolts)
+          if (data.type === 'rocket' || data.type === 'stickybomb' || data.type === 'pipebomb') {
+            newExplosions.push({
+              id: nextExplosionId++,
+              position: data.position.clone(),
+              type: data.type,
+              teamNumber: data.teamNumber,
+              startTime: performance.now(),
+            })
+          }
+        }
+      })
+
+      if (newExplosions.length > 0) {
+        setExplosions(prev => [...prev, ...newExplosions])
+      }
+    }
+
+    // Update tracking map
+    const nextMap = new Map<
+      number,
+      { position: THREE.Vector3; type: string; teamNumber: number }
+    >()
+    projectiles.forEach(p => {
+      nextMap.set(p.entityId, {
+        position: objCoordsToVector3(p.position),
+        type: p.type,
+        teamNumber: p.teamNumber,
+      })
+    })
+    prevProjectileIds.current = nextMap
+    prevTick.current = tick
+
+    // Clear explosions on scrub (non-forward-step)
+    if (!isForwardStep && tick !== prevTick.current) {
+      setExplosions([])
+    }
+  }, [tick, projectiles])
+
+  const removeExplosion = useCallback((id: number) => {
+    setExplosions(prev => prev.filter(e => e.id !== id))
+  }, [])
 
   return (
     <group name="projectiles">
@@ -69,8 +260,19 @@ export const Projectiles = (props: ProjectilesProps) => {
         if (projectile.type === 'healingBolt') Projectile = HealingBoltProjectile
         if (!Projectile) return null
 
-        return <Projectile key={`projectile-${projectile.entityId}`} {...projectile} />
+        return (
+          <Projectile
+            key={`projectile-${projectile.entityId}`}
+            {...projectile}
+            renderTick={tick}
+            intervalPerTick={intervalPerTick}
+          />
+        )
       })}
+
+      {explosions.map(explosion => (
+        <ExplosionEffect key={explosion.id} explosion={explosion} onComplete={removeExplosion} />
+      ))}
     </group>
   )
 }
@@ -79,7 +281,26 @@ export const Projectiles = (props: ProjectilesProps) => {
 // ─── BASE PROJECTILE ────────────────────────────────────────────────────────────
 //
 
-export interface BaseProjectileProps extends InterpolatedProjectile {}
+export interface BaseProjectileProps extends InterpolatedProjectile {
+  renderTick: number
+  intervalPerTick: number
+}
+
+//
+// ─── TRAIL CONFIG HOOK ──────────────────────────────────────────────────────────
+//
+
+function useTrailConfig(baseWidth: number = 10) {
+  const controlsMode = useStore(state => state.scene.controls.mode)
+  const isPov = controlsMode === 'pov'
+
+  return useMemo(() => {
+    const width = isPov ? baseWidth : baseWidth * 0.9
+    const attenuation = (t: number) => 0.5 * width * t
+
+    return { width, attenuation, isPov }
+  }, [isPov, baseWidth])
+}
 
 //
 // ─── ROCKET PROJECTILE ──────────────────────────────────────────────────────────
@@ -87,46 +308,74 @@ export interface BaseProjectileProps extends InterpolatedProjectile {}
 
 export const RocketProjectile = (props: BaseProjectileProps) => {
   const ref = useRef<THREE.Group>(null)
-  const prevPosition = useRef<THREE.Vector3>(objCoordsToVector3(props.position))
+  const trailMeshRef = useRef<any>(null)
+  const prevLookAtPosition = useRef<THREE.Vector3>(objCoordsToVector3(props.position))
   const interpolatedPosition = useRef(new THREE.Vector3())
+  const smoothedPosition = useRef(new THREE.Vector3())
   const position = objCoordsToVector3(props.position)
   const positionNext = objCoordsToVector3(props.positionNext)
   const hasRenderInit = useRef(false)
+  const trailConfig = useTrailConfig(15)
 
   // Use lookAt from prev pos -> current pos for rotation (parser rotation is unreliable)
   useEffect(() => {
-    if (!prevPosition.current?.equals(position)) {
-      ref.current?.lookAt(prevPosition.current)
-      prevPosition.current = objCoordsToVector3(position)
+    if (!prevLookAtPosition.current?.equals(position)) {
+      ref.current?.lookAt(prevLookAtPosition.current)
+      prevLookAtPosition.current = objCoordsToVector3(position)
     }
   }, [position])
 
-  useFrame(() => {
+  // Customize trail material for gradient effect
+  useEffect(() => {
+    if (!trailMeshRef.current) return
+    const material = trailMeshRef.current.material
+    if (!material) return
+
+    if (trailConfig.isPov) {
+      material.blending = THREE.AdditiveBlending
+      material.depthTest = false
+      material.transparent = true
+    } else {
+      material.blending = THREE.NormalBlending
+      material.depthTest = true
+      material.transparent = true
+      material.opacity = 0.5
+    }
+  }, [trailConfig.isPov])
+
+  useFrame((_, delta) => {
     const frameProgress = useInstance.getState().frameProgress
     if (!ref.current) return
 
     const lerpProgress = Math.min(Math.max(frameProgress, 0), 0.999)
-    const didTeleport = position.distanceTo(positionNext) > TELEPORT_LERP_DISTANCE
+    const alpha = smoothingAlpha(PROJECTILE_POSITION_SMOOTH_SECONDS, delta)
 
-    if (didTeleport) {
-      ref.current.position.copy(position)
+    interpolatePosition(position, positionNext, lerpProgress, interpolatedPosition.current)
+
+    if (!hasRenderInit.current) {
+      smoothedPosition.current.copy(interpolatedPosition.current)
+      ref.current.position.copy(interpolatedPosition.current)
+      hasRenderInit.current = true
     } else {
-      interpolatedPosition.current.copy(position).lerp(positionNext, lerpProgress)
-      if (!hasRenderInit.current) {
-        ref.current.position.copy(interpolatedPosition.current)
-        hasRenderInit.current = true
-      } else {
-        ref.current.position.lerp(interpolatedPosition.current, 0.5)
-      }
+      smoothedPosition.current.lerp(interpolatedPosition.current, alpha)
+      ref.current.position.copy(smoothedPosition.current)
     }
   })
 
   return (
-    <group name="rocket" ref={ref} position={position}>
-      <Suspense fallback={null}>
-        <ProjectileModel type="rocket" team="shared" />
-      </Suspense>
-    </group>
+    <Trail
+      ref={trailMeshRef}
+      width={trailConfig.width}
+      length={3}
+      color={ROCKET_TRAIL_COLOR}
+      attenuation={trailConfig.attenuation}
+    >
+      <group name="rocket" ref={ref} position={position}>
+        <Suspense fallback={<ProjectileFallback />}>
+          <ProjectileModel type="rocket" team="shared" />
+        </Suspense>
+      </group>
+    </Trail>
   )
 }
 
@@ -136,8 +385,11 @@ export const RocketProjectile = (props: BaseProjectileProps) => {
 
 export const PipebombProjectile = (props: BaseProjectileProps) => {
   const team = TEAM_MAP[props.teamNumber]
+  const teamColor = TEAM_COLORS[team] ?? TRAIL_FALLBACK_COLOR
   const ref = useRef<THREE.Group>(null)
+  const trailMeshRef = useRef<any>(null)
   const interpolatedPosition = useRef(new THREE.Vector3())
+  const smoothedPosition = useRef(new THREE.Vector3())
   const position = objCoordsToVector3(props.position)
   const positionNext = objCoordsToVector3(props.positionNext)
   const rotation = eulerizeVector(props.rotation)
@@ -146,40 +398,75 @@ export const PipebombProjectile = (props: BaseProjectileProps) => {
   const nextQuat = useRef(new THREE.Quaternion())
   const interpolatedQuat = useRef(new THREE.Quaternion())
   const hasRenderInit = useRef(false)
+  const trailConfig = useTrailConfig()
 
-  useFrame(() => {
+  // Customize trail material
+  useEffect(() => {
+    if (!trailMeshRef.current) return
+    const material = trailMeshRef.current.material
+    if (!material) return
+
+    if (trailConfig.isPov) {
+      material.blending = THREE.AdditiveBlending
+      material.depthTest = false
+      material.transparent = true
+    } else {
+      material.blending = THREE.NormalBlending
+      material.depthTest = true
+      material.transparent = true
+      material.opacity = 0.5
+    }
+  }, [trailConfig.isPov])
+
+  useFrame((_, delta) => {
     const frameProgress = useInstance.getState().frameProgress
     if (!ref.current) return
 
     const lerpProgress = Math.min(Math.max(frameProgress, 0), 0.999)
+    const posAlpha = smoothingAlpha(PROJECTILE_POSITION_SMOOTH_SECONDS, delta)
+    const rotAlpha = smoothingAlpha(PROJECTILE_ROTATION_SMOOTH_SECONDS, delta)
+
     const didTeleport = position.distanceTo(positionNext) > TELEPORT_LERP_DISTANCE
 
     if (didTeleport) {
       ref.current.position.copy(position)
       ref.current.rotation.copy(rotation)
+      smoothedPosition.current.copy(position)
       hasRenderInit.current = true
       return
     }
 
-    interpolatedPosition.current.copy(position).lerp(positionNext, lerpProgress)
+    interpolatePosition(position, positionNext, lerpProgress, interpolatedPosition.current)
     currentQuat.current.setFromEuler(rotation)
     nextQuat.current.setFromEuler(rotationNext)
     interpolatedQuat.current.copy(currentQuat.current).slerp(nextQuat.current, lerpProgress)
 
     if (!hasRenderInit.current) {
+      smoothedPosition.current.copy(interpolatedPosition.current)
       ref.current.position.copy(interpolatedPosition.current)
       ref.current.quaternion.copy(interpolatedQuat.current)
       hasRenderInit.current = true
     } else {
-      ref.current.position.lerp(interpolatedPosition.current, 0.5)
-      ref.current.quaternion.slerp(interpolatedQuat.current, 0.5)
+      smoothedPosition.current.lerp(interpolatedPosition.current, posAlpha)
+      ref.current.position.copy(smoothedPosition.current)
+      ref.current.quaternion.slerp(interpolatedQuat.current, rotAlpha)
     }
   })
 
   return (
-    <group name="pipebomb" ref={ref} position={position} rotation={rotation}>
-      <Suspense fallback={null}>{team && <ProjectileModel type="pipebomb" team={team} />}</Suspense>
-    </group>
+    <Trail
+      ref={trailMeshRef}
+      width={trailConfig.width}
+      length={1}
+      color={teamColor}
+      attenuation={trailConfig.attenuation}
+    >
+      <group name="pipebomb" ref={ref} position={position} rotation={rotation}>
+        <Suspense fallback={<ProjectileFallback color={teamColor} />}>
+          {team && <ProjectileModel type="pipebomb" team={team} />}
+        </Suspense>
+      </group>
+    </Trail>
   )
 }
 
@@ -189,8 +476,11 @@ export const PipebombProjectile = (props: BaseProjectileProps) => {
 
 export const StickybombProjectile = (props: BaseProjectileProps) => {
   const team = TEAM_MAP[props.teamNumber]
+  const teamColor = TEAM_COLORS[team] ?? TRAIL_FALLBACK_COLOR
   const ref = useRef<THREE.Group>(null)
+  const trailMeshRef = useRef<any>(null)
   const interpolatedPosition = useRef(new THREE.Vector3())
+  const smoothedPosition = useRef(new THREE.Vector3())
   const position = objCoordsToVector3(props.position)
   const positionNext = objCoordsToVector3(props.positionNext)
   const rotation = eulerizeVector(props.rotation)
@@ -199,42 +489,75 @@ export const StickybombProjectile = (props: BaseProjectileProps) => {
   const nextQuat = useRef(new THREE.Quaternion())
   const interpolatedQuat = useRef(new THREE.Quaternion())
   const hasRenderInit = useRef(false)
+  const trailConfig = useTrailConfig()
 
-  useFrame(() => {
+  // Customize trail material
+  useEffect(() => {
+    if (!trailMeshRef.current) return
+    const material = trailMeshRef.current.material
+    if (!material) return
+
+    if (trailConfig.isPov) {
+      material.blending = THREE.AdditiveBlending
+      material.depthTest = false
+      material.transparent = true
+    } else {
+      material.blending = THREE.NormalBlending
+      material.depthTest = true
+      material.transparent = true
+      material.opacity = 0.5
+    }
+  }, [trailConfig.isPov])
+
+  useFrame((_, delta) => {
     const frameProgress = useInstance.getState().frameProgress
     if (!ref.current) return
 
     const lerpProgress = Math.min(Math.max(frameProgress, 0), 0.999)
+    const posAlpha = smoothingAlpha(PROJECTILE_POSITION_SMOOTH_SECONDS, delta)
+    const rotAlpha = smoothingAlpha(PROJECTILE_ROTATION_SMOOTH_SECONDS, delta)
+
     const didTeleport = position.distanceTo(positionNext) > TELEPORT_LERP_DISTANCE
 
     if (didTeleport) {
       ref.current.position.copy(position)
       ref.current.rotation.copy(rotation)
+      smoothedPosition.current.copy(position)
       hasRenderInit.current = true
       return
     }
 
-    interpolatedPosition.current.copy(position).lerp(positionNext, lerpProgress)
+    interpolatePosition(position, positionNext, lerpProgress, interpolatedPosition.current)
     currentQuat.current.setFromEuler(rotation)
     nextQuat.current.setFromEuler(rotationNext)
     interpolatedQuat.current.copy(currentQuat.current).slerp(nextQuat.current, lerpProgress)
 
     if (!hasRenderInit.current) {
+      smoothedPosition.current.copy(interpolatedPosition.current)
       ref.current.position.copy(interpolatedPosition.current)
       ref.current.quaternion.copy(interpolatedQuat.current)
       hasRenderInit.current = true
     } else {
-      ref.current.position.lerp(interpolatedPosition.current, 0.5)
-      ref.current.quaternion.slerp(interpolatedQuat.current, 0.5)
+      smoothedPosition.current.lerp(interpolatedPosition.current, posAlpha)
+      ref.current.position.copy(smoothedPosition.current)
+      ref.current.quaternion.slerp(interpolatedQuat.current, rotAlpha)
     }
   })
 
   return (
-    <group name="stickybomb" ref={ref} position={position} rotation={rotation}>
-      <Suspense fallback={null}>
-        {team && <ProjectileModel type="stickybomb" team={team} />}
-      </Suspense>
-    </group>
+    <Trail
+      ref={trailMeshRef}
+      width={trailConfig.width}
+      length={2}
+      color={teamColor}
+      attenuation={trailConfig.attenuation}
+    >
+      <group name="stickybomb" ref={ref} position={position} rotation={rotation}>
+        <Suspense fallback={<ProjectileFallback color={teamColor} />}>
+          {team && <ProjectileModel type="stickybomb" team={team} />}
+        </Suspense>
+      </group>
+    </Trail>
   )
 }
 
@@ -243,11 +566,65 @@ export const StickybombProjectile = (props: BaseProjectileProps) => {
 //
 
 export const HealingBoltProjectile = (props: BaseProjectileProps) => {
+  const ref = useRef<THREE.Group>(null)
+  const trailMeshRef = useRef<any>(null)
+  const interpolatedPosition = useRef(new THREE.Vector3())
+  const smoothedPosition = useRef(new THREE.Vector3())
+  const position = objCoordsToVector3(props.position)
+  const positionNext = objCoordsToVector3(props.positionNext)
+  const hasRenderInit = useRef(false)
+  const trailConfig = useTrailConfig()
+
+  // Customize trail material
+  useEffect(() => {
+    if (!trailMeshRef.current) return
+    const material = trailMeshRef.current.material
+    if (!material) return
+
+    if (trailConfig.isPov) {
+      material.blending = THREE.AdditiveBlending
+      material.depthTest = false
+      material.transparent = true
+    } else {
+      material.blending = THREE.NormalBlending
+      material.depthTest = true
+      material.transparent = true
+      material.opacity = 0.5
+    }
+  }, [trailConfig.isPov])
+
+  useFrame((_, delta) => {
+    const frameProgress = useInstance.getState().frameProgress
+    if (!ref.current) return
+
+    const lerpProgress = Math.min(Math.max(frameProgress, 0), 0.999)
+    const alpha = smoothingAlpha(PROJECTILE_POSITION_SMOOTH_SECONDS, delta)
+
+    interpolatePosition(position, positionNext, lerpProgress, interpolatedPosition.current)
+
+    if (!hasRenderInit.current) {
+      smoothedPosition.current.copy(interpolatedPosition.current)
+      ref.current.position.copy(interpolatedPosition.current)
+      hasRenderInit.current = true
+    } else {
+      smoothedPosition.current.lerp(interpolatedPosition.current, alpha)
+      ref.current.position.copy(smoothedPosition.current)
+    }
+  })
+
   return (
-    <group name="healingBolt" position={objCoordsToVector3(props.position)}>
-      <Sphere args={[5]}>
-        <meshLambertMaterial attach="material" color="yellow" />
-      </Sphere>
-    </group>
+    <Trail
+      ref={trailMeshRef}
+      width={trailConfig.width}
+      length={2}
+      color="#e8d44d"
+      attenuation={trailConfig.attenuation}
+    >
+      <group name="healingBolt" ref={ref} position={position}>
+        <Sphere args={[5]}>
+          <meshLambertMaterial attach="material" color="yellow" />
+        </Sphere>
+      </group>
+    </Trail>
   )
 }


### PR DESCRIPTION
  # Summary

  - Add smoke puff trails for rockets and MeshLine trails for stickybombs, pipebombs, and healing bolts
  - Add explosion effects (expanding/fading spheres) when projectiles detonate, detected by tracking entity disappearance between ticks
  - Improve projectile interpolation with prev/next2 tick data and smoothingAlpha for smoother trail rendering
  - Trails render in all camera modes (POV: bold style, 3rd-person: subtler)

  # Test plan

  - Load a demo with rockets — verify smoke puff trails appear behind rockets
  - Load a demo with stickybombs/pipebombs — verify team-colored MeshLine trails appear
  - Watch projectiles detonate — verify expanding sphere explosion effect at detonation point
  - Switch between RTS/Spectator/POV camera modes — verify trails render in all modes
  - Scrub timeline back and forth — verify no trail/explosion artifacts persist
  - Test with many simultaneous projectiles — verify performance is acceptable