### PR TITLE
feat: add killfeed panel for important match events

### DIFF
--- a/specs/match-killfeed-panel.md
+++ b/specs/match-killfeed-panel.md
@@ -1,0 +1,79 @@
+Match Killfeed Panel
+
+Context
+
+The existing killfeed (Killfeed.tsx) only shows kills within a 200-tick window of the current
+playback position. Users need a way to see ALL kills in the entire match to quickly locate
+specific moments — especially kills by/against a particular player. This panel provides a
+searchable, scrollable list of every kill event with timestamps for instant seeking.
+
+Files to Create
+
+1. src/utils/matchEvents.ts — Event extraction utilities
+
+- getAllKills(parser): Flattens parser.deaths (keyed by tick) into a sorted MatchKillEvent[]
+array
+- getUberPops(parser): Scans parser.playerCache.uberCache for medics (classId 5) whose charge
+drops from ~100 to a lower value. Returns MatchUberEvent[] with medic identity and tick
+- Types: MatchKillEvent, MatchUberEvent, MatchEvent (union)
+
+2. src/components/UI/MatchKillfeedPanel.tsx — Main panel component
+
+Structure:
+MatchKillfeedPanel
+  TogglePanelButton (list icon)
+  TogglePanel (slide-in, following SettingsPanel/AboutPanel pattern)
+    Header: "Match Killfeed"
+    Filter input (text, filters by player name across killer/victim/assister)
+    "Uber pops" checkbox toggle
+    Event count indicator
+    Scrollable list of MatchEventRow items
+      Kill rows: timestamp | killer [+assister] | weapon icon | victim
+      Uber rows: timestamp | medic name | "popped uber"
+
+- Clicking any row calls goToTickAction(tick) to seek playback
+- Kill rendering reuses weapon icon pattern from existing KillfeedItem (kill icon aliases, team
+colors, fallback skull icon)
+- All events computed via useMemo (keyed on parser + showUberPops), filtering via useMemo
+(keyed on events + filterText)
+
+Files to Modify
+
+3. src/constants/types.ts — Add panel type
+
+Add MATCH_KILLFEED: 'MatchKillfeed' to the UIPanelType const. The existing toggleUIPanelAction
+and reducer cases work generically with any UIPanelType value.
+
+4. src/components/DemoViewer.tsx — Wire panel into UI
+
+- Import MatchKillfeedPanel
+- Add a new ui-layer div below the AboutPanel layer, guarded by {demo && ...} since the data
+depends on a loaded demo
+- Position: left side, below the existing About button (mt-28 roughly — will tune visually)
+
+Key Patterns to Reuse
+
+- TogglePanelButton + TogglePanel from src/components/UI/Shared/TogglePanel.tsx
+- toggleUIPanelAction from src/zustand/actions.ts for panel open/close state
+- KillfeedItem weapon icon pattern from src/components/UI/Killfeed.tsx (icon aliases, team
+color classes, error fallback)
+- getDurationFromTicks() from src/utils/parser.ts for timestamp formatting
+- goToTickAction() from src/zustand/actions.ts for seeking
+- useInstance(state => state.parsedDemo) to access the parser
+- useStore(state => state.ui.activePanels) for panel visibility
+
+Uber Pop Detection
+
+ChargeLevel data is sampled every 16 ticks (~0.24s) via SparseDataCache. We detect a "pop" when
+a medic's charge drops from >=95 to <50 between consecutive samples. This gives ~0.24s
+accuracy, which is sufficient for seeking purposes.
+
+Verification
+
+1. Load a demo file and confirm the panel toggle button appears on the left side
+2. Open the panel — verify all kills are listed with correct timestamps, names, weapon icons,
+and team colors
+3. Type a player name in the filter — verify the list filters to kills involving that player
+4. Click a row — verify playback seeks to that tick
+5. Toggle "Uber pops" — verify uber events appear/disappear from the list
+6. Confirm no performance issues with the scrollable list

--- a/src/components/Analyse/Data/ParseWorker.ts
+++ b/src/components/Analyse/Data/ParseWorker.ts
@@ -15,6 +15,8 @@ type WasmPlayerCache = {
   health: Uint16Array[]
   meta: Uint8Array[]
   connected: Uint8Array[]
+  uber: Uint16Array[]
+  healTarget: Uint16Array[]
 }
 
 type WasmProjectileCache = {
@@ -143,6 +145,8 @@ onmessage = async (event: MessageEvent) => {
     playerCache.healthCache.data = wasmPlayerCache.health as any
     playerCache.metaCache.data = wasmPlayerCache.meta as any
     playerCache.connectedCache.data = wasmPlayerCache.connected as any
+    playerCache.uberCache.data = wasmPlayerCache.uber as any
+    playerCache.healTargetCache.data = wasmPlayerCache.healTarget as any
 
     // Empty building cache (WASM parser does not output building data)
     const buildingCache = new BuildingCache(ticks, world.boundaryMin)
@@ -216,7 +220,9 @@ onmessage = async (event: MessageEvent) => {
       sumBytes(playerCache.viewAnglesCache.data) +
       sumBytes(playerCache.healthCache.data) +
       sumBytes(playerCache.metaCache.data) +
-      sumBytes(playerCache.connectedCache.data)
+      sumBytes(playerCache.connectedCache.data) +
+      sumBytes(playerCache.uberCache.data) +
+      sumBytes(playerCache.healTargetCache.data)
     const projectileCacheBytes =
       sumBytes(projectileCache.positionCache.data) +
       sumBytes(projectileCache.rotationCache.data) +
@@ -265,6 +271,8 @@ onmessage = async (event: MessageEvent) => {
     pushBuffers(transfers, playerCache.healthCache.data)
     pushBuffers(transfers, playerCache.metaCache.data)
     pushBuffers(transfers, playerCache.connectedCache.data)
+    pushBuffers(transfers, playerCache.uberCache.data)
+    pushBuffers(transfers, playerCache.healTargetCache.data)
     pushBuffers(transfers, projectileCache.positionCache.data)
     pushBuffers(transfers, projectileCache.rotationCache.data)
     pushBuffers(transfers, projectileCache.teamNumberCache.data)

--- a/src/components/DemoViewer.tsx
+++ b/src/components/DemoViewer.tsx
@@ -29,6 +29,7 @@ import { PlaybackPanel } from '@components/UI/PlaybackPanel'
 import { Killfeed } from '@components/UI/Killfeed'
 import { PlayerStatuses } from '@components/UI/PlayerStatuses'
 import { FocusedPlayer } from '@components/UI/FocusedPlayer'
+import { MatchKillfeedPanel } from '@components/UI/MatchKillfeedPanel'
 import { FpsCounter } from '@components/UI/FpsCounter'
 
 // Actions & utils
@@ -433,6 +434,12 @@ class DemoViewer extends Component<DemoViewerProps> {
           <div className="ui-layer justift-start m-4 mt-16 items-start">
             <AboutPanel />
           </div>
+
+          {demo && (
+            <div className="ui-layer m-4 mt-28 items-start justify-start">
+              <MatchKillfeedPanel />
+            </div>
+          )}
         </div>
       </div>
     )

--- a/src/components/Misc/Icons.tsx
+++ b/src/components/Misc/Icons.tsx
@@ -146,6 +146,27 @@ export const FaUndoIcon = (props: SVGProps<SVGSVGElement>) => {
   )
 }
 
+export const HiListBulletIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm-.375 5.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"
+      />
+    </svg>
+  )
+}
+
 export const FaTrashIcon = (props: SVGProps<SVGSVGElement>) => {
   return (
     <svg

--- a/src/components/UI/AboutPanel.tsx
+++ b/src/components/UI/AboutPanel.tsx
@@ -42,6 +42,7 @@ export const AboutPanel = () => {
 
   const toggleUIPanel = () => {
     toggleUIPanelAction('Settings', false)
+    toggleUIPanelAction('MatchKillfeed', false)
     toggleUIPanelAction('About')
   }
 

--- a/src/components/UI/MatchKillfeedPanel.tsx
+++ b/src/components/UI/MatchKillfeedPanel.tsx
@@ -1,0 +1,223 @@
+import { useState, useMemo } from 'react'
+
+import { TogglePanel, TogglePanelButton } from '@components/UI/Shared/TogglePanel'
+import { HiListBulletIcon } from '@components/Misc/Icons'
+
+import { useStore, useInstance } from '@zus/store'
+import { toggleUIPanelAction, goToTickAction, jumpToPlayerPOVCamera } from '@zus/actions'
+import { getAllKills, getUberPops, MatchEvent, MatchKillEvent } from '@utils/matchEvents'
+import { getDurationFromTicks } from '@utils/parser'
+import { KILL_ICON_ALIASES } from '@constants/killIconAliases'
+import { cn } from '@utils/styling'
+
+const teamTextColorMap: { [key: string]: string } = {
+  red: 'text-pp-killfeed-text-red',
+  blue: 'text-pp-killfeed-text-blue',
+}
+
+const teamIdToName = (teamId: number): string => {
+  if (teamId === 2) return 'red'
+  if (teamId === 3) return 'blue'
+  return ''
+}
+
+export const MatchKillfeedPanel = () => {
+  const isOpen = useStore(state => state.ui.activePanels.includes('MatchKillfeed'))
+  const parser = useInstance(state => state.parsedDemo)
+
+  const [filterText, setFilterText] = useState('')
+
+  const toggleUIPanel = () => {
+    toggleUIPanelAction('Settings', false)
+    toggleUIPanelAction('About', false)
+    toggleUIPanelAction('MatchKillfeed')
+  }
+
+  const events = useMemo(() => {
+    if (!parser) return []
+    const kills: MatchEvent[] = getAllKills(parser)
+    const ubers: MatchEvent[] = getUberPops(parser)
+    return [...kills, ...ubers].sort((a, b) => a.tick - b.tick)
+  }, [parser])
+
+  const filteredEvents = useMemo(() => {
+    if (!filterText) return events
+    const query = filterText.toLowerCase()
+    return events.filter(event => {
+      if (event.type === 'kill') {
+        return (
+          event.killer?.user.name.toLowerCase().includes(query) ||
+          event.victim.user.name.toLowerCase().includes(query) ||
+          event.assister?.user.name.toLowerCase().includes(query)
+        )
+      }
+      return event.medicName.toLowerCase().includes(query)
+    })
+  }, [events, filterText])
+
+  const tickRate = parser?.intervalPerTick ? 1 / parser.intervalPerTick : 66.67
+  const killfeedSeekBuffer = useStore(state => state.settings.ui.killfeedSeekBuffer)
+
+  const onClickEvent = (event: MatchEvent) => {
+    const bufferTicks = Math.round(killfeedSeekBuffer * tickRate)
+    goToTickAction(Math.max(1, event.tick - bufferTicks))
+
+    if (event.type === 'kill') {
+      const entityId = event.killer?.user.entityId ?? event.victim.user.entityId
+      jumpToPlayerPOVCamera(entityId)
+    } else {
+      jumpToPlayerPOVCamera(event.medicEntityId)
+    }
+  }
+
+  return (
+    <div className="flex items-start">
+      <TogglePanelButton onClick={toggleUIPanel}>
+        <HiListBulletIcon />
+      </TogglePanelButton>
+
+      <TogglePanel showCloseButton isOpen={isOpen} onClickClose={toggleUIPanel}>
+        <div className="w-[520px] px-6 pb-6 pt-6">
+          <div className="relative mb-3 mr-8">
+            <input
+              type="text"
+              placeholder="Filter by player name..."
+              value={filterText}
+              onChange={e => setFilterText(e.target.value)}
+              className="w-full rounded-lg bg-white/10 px-3 py-1.5 pr-8 text-sm outline-none placeholder:text-white/40"
+            />
+            {filterText && (
+              <button
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-white/40 transition-colors hover:text-white"
+                onClick={() => setFilterText('')}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                  <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+                </svg>
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-[60vh] overflow-y-auto">
+            {filteredEvents.map((event, index) => (
+              <MatchEventRow
+                key={`${event.type}-${event.tick}-${index}`}
+                event={event}
+                tickRate={tickRate}
+                onClick={() => onClickEvent(event)}
+                onFilter={setFilterText}
+              />
+            ))}
+          </div>
+        </div>
+      </TogglePanel>
+    </div>
+  )
+}
+
+// ─── EVENT ROW ──────────────────────────────────────────────────────────────────
+
+interface MatchEventRowProps {
+  event: MatchEvent
+  tickRate: number
+  onClick: () => void
+  onFilter: (name: string) => void
+}
+
+const MatchEventRow = ({ event, tickRate, onClick, onFilter }: MatchEventRowProps) => {
+  const timestamp = getDurationFromTicks(event.tick, tickRate).formatted
+
+  if (event.type === 'uber') {
+    const teamColor = teamTextColorMap[teamIdToName(event.medicTeam)] || ''
+    return (
+      <div
+        className="mb-1 flex cursor-pointer items-center rounded-lg px-2 py-1 text-xs hover:bg-white/10"
+        onClick={onClick}
+      >
+        <span className="mr-3 w-12 flex-shrink-0 font-mono text-white/50">{timestamp}</span>
+        <FilterButton onClick={() => onFilter(event.medicName)} />
+        <span className={cn('font-bold', teamColor)}>{event.medicName}</span>
+        <span className="ml-2 italic text-yellow-300">popped uber</span>
+      </div>
+    )
+  }
+
+  return <KillRow event={event} timestamp={timestamp} onClick={onClick} onFilter={onFilter} />
+}
+
+// ─── KILL ROW ───────────────────────────────────────────────────────────────────
+
+interface KillRowProps {
+  event: MatchKillEvent
+  timestamp: string
+  onClick: () => void
+  onFilter: (name: string) => void
+}
+
+const KillRow = ({ event, timestamp, onClick, onFilter }: KillRowProps) => {
+  const { killer, victim, assister, weapon } = event
+
+  const iconName = KILL_ICON_ALIASES[weapon] || weapon
+  const [weaponIcon, setWeaponIcon] = useState(
+    new URL(`/src/assets/kill_icons/${iconName}.png`, import.meta.url).href
+  )
+
+  const onWeaponIconError = () => {
+    setWeaponIcon(new URL(`/src/assets/kill_icons/skull.png`, import.meta.url).href)
+  }
+
+  const killerTeamColor = killer ? teamTextColorMap[killer.user.team] || '' : ''
+  const victimTeamColor = teamTextColorMap[victim.user.team] || ''
+  const filterName = killer && killer !== victim ? killer.user.name : victim.user.name
+
+  return (
+    <div
+      className="mb-1 flex cursor-pointer items-center rounded-lg px-2 py-1 text-xs hover:bg-white/10"
+      onClick={onClick}
+    >
+      <span className="mr-3 w-12 flex-shrink-0 font-mono text-white/50">{timestamp}</span>
+      <FilterButton onClick={() => onFilter(filterName)} />
+
+      <div className="flex min-w-0 flex-1 items-center">
+        {killer && killer !== victim && (
+          <span className={cn('truncate font-bold', killerTeamColor)}>{killer.user.name}</span>
+        )}
+
+        {assister && (
+          <>
+            <span className={cn('mx-1', killerTeamColor)}>+</span>
+            <span className={cn('truncate font-bold', killerTeamColor)}>{assister.user.name}</span>
+          </>
+        )}
+
+        <div className="mx-2 inline-flex flex-shrink-0 items-center">
+          <img
+            src={weaponIcon}
+            className="h-[0.9rem] brightness-[600%]"
+            alt={weapon}
+            onError={onWeaponIconError}
+          />
+        </div>
+
+        <span className={cn('truncate font-bold', victimTeamColor)}>{victim.user.name}</span>
+      </div>
+    </div>
+  )
+}
+
+// ─── FILTER BUTTON ──────────────────────────────────────────────────────────────
+
+const FilterButton = ({ onClick }: { onClick: () => void }) => (
+  <button
+    className="mr-2 flex-shrink-0 rounded p-0.5 text-white/25 transition-colors hover:text-white"
+    onClick={e => {
+      e.stopPropagation()
+      onClick()
+    }}
+    title="Filter by this player"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3">
+      <path fillRule="evenodd" d="M2.628 1.601C5.028 1.206 7.49 1 10 1s4.973.206 7.372.601a.75.75 0 01.628.74v2.288a2.25 2.25 0 01-.659 1.59l-4.682 4.683a2.25 2.25 0 00-.659 1.59v3.037c0 .684-.31 1.33-.844 1.757l-1.937 1.55A.75.75 0 018 18.25v-5.757a2.25 2.25 0 00-.659-1.591L2.659 6.22A2.25 2.25 0 012 4.629V2.34a.75.75 0 01.628-.74z" clipRule="evenodd" />
+    </svg>
+  </button>
+)

--- a/src/components/UI/SettingsPanel.tsx
+++ b/src/components/UI/SettingsPanel.tsx
@@ -144,6 +144,7 @@ export const SettingsPanel = () => {
 
   const toggleUIPanel = () => {
     toggleUIPanelAction('About', false)
+    toggleUIPanelAction('MatchKillfeed', false)
     toggleUIPanelAction('Settings')
   }
   const updateSettingsOption = (option: string, value: any) => {
@@ -365,6 +366,15 @@ export const SettingsPanel = () => {
             label="Show Skybox"
             checked={settings.ui.showSkybox}
             onChange={checked => updateSettingsOption('ui.showSkybox', checked)}
+          />
+
+          <SliderOption
+            label="Killfeed seek buffer"
+            min={1}
+            max={10}
+            step={1}
+            value={settings.ui.killfeedSeekBuffer}
+            onChange={value => updateSettingsOption('ui.killfeedSeekBuffer', value)}
           />
         </div>
       </TogglePanel>

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -32,6 +32,7 @@ export type DrawingActivation = (typeof DrawingActivation)[keyof typeof DrawingA
 export const UIPanelType = {
   ABOUT: 'About',
   SETTINGS: 'Settings',
+  MATCH_KILLFEED: 'MatchKillfeed',
 } as const
 
 export type UIPanelType = (typeof UIPanelType)[keyof typeof UIPanelType]

--- a/src/utils/matchEvents.ts
+++ b/src/utils/matchEvents.ts
@@ -1,0 +1,82 @@
+import { AsyncParser, CachedDeath } from '@components/Analyse/Data/AsyncParser'
+
+export interface MatchKillEvent {
+  type: 'kill'
+  tick: number
+  killer: CachedDeath['killer']
+  victim: CachedDeath['victim']
+  assister: CachedDeath['assister']
+  weapon: string
+  killerTeam: number
+  victimTeam: number
+  assisterTeam: number
+}
+
+export interface MatchUberEvent {
+  type: 'uber'
+  tick: number
+  medicName: string
+  medicTeam: number
+  medicEntityId: number
+}
+
+export type MatchEvent = MatchKillEvent | MatchUberEvent
+
+export function getAllKills(parser: AsyncParser): MatchKillEvent[] {
+  const kills: MatchKillEvent[] = []
+
+  for (const tickKey in parser.deaths) {
+    const deaths = parser.deaths[tickKey]
+    for (const death of deaths) {
+      kills.push({
+        type: 'kill',
+        tick: death.tick,
+        killer: death.killer,
+        victim: death.victim,
+        assister: death.assister,
+        weapon: death.weapon,
+        killerTeam: death.killerTeam,
+        victimTeam: death.victimTeam,
+        assisterTeam: death.assisterTeam,
+      })
+    }
+  }
+
+  kills.sort((a, b) => a.tick - b.tick)
+  return kills
+}
+
+export function getUberPops(parser: AsyncParser): MatchUberEvent[] {
+  const events: MatchUberEvent[] = []
+  const { uberCache, metaCache } = parser.playerCache
+  const step = 1 << uberCache.sparse
+
+  for (let i = 0; i < parser.nextMappedPlayer; i++) {
+    const entity = parser.entityPlayerMap.get(i)
+    if (!entity) continue
+
+    for (let tick = step; tick < parser.ticks; tick += step) {
+      const prevCharge = uberCache.getOrNull(i, tick - step)
+      const currCharge = uberCache.getOrNull(i, tick)
+
+      // Detect when charge crosses below 95 from a near-full state.
+      // Uber drains ~3% per 16-tick sample, so a single-step drop from
+      // >=95 to <95 reliably catches the first moment of activation.
+      if (prevCharge !== null && currCharge !== null && prevCharge >= 95 && currCharge < 95) {
+        const meta = metaCache.getMeta(i, tick)
+        if (meta.classId === 5) {
+          events.push({
+            type: 'uber',
+            tick,
+            medicName: entity.user.name,
+            medicTeam: meta.teamId,
+            medicEntityId: entity.user.entityId,
+          })
+        }
+      }
+    }
+  }
+
+  events.sort((a, b) => a.tick - b.tick)
+  return events
+}

--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -131,6 +131,7 @@ export type StoreState = {
       showStats: boolean
       showSkybox: boolean
       viewDistance: number
+      killfeedSeekBuffer: number
     }
   }
   ui: {
@@ -210,6 +211,7 @@ export const initialState: StoreState = {
       showStats: false,
       showSkybox: true,
       viewDistance: 15000,
+      killfeedSeekBuffer: 2,
     },
   },
 


### PR DESCRIPTION
  ## Summary
  - Adds a new **Match Killfeed** panel that shows all kills and uber pops for the entire match, with timestamps for instant seeking
  - Includes a player name filter, per-row filter buttons, and a configurable seek buffer setting
  - Detects uber pops by scanning medic charge data for activation drops

  ## Changes
  - **New:** `MatchKillfeedPanel.tsx` — slide-in panel with filterable event list, reuses TogglePanel/weapon icon patterns
  - **New:** `matchEvents.ts` — `getAllKills()` and `getUberPops()` extraction utilities
  - **Modified:** `ParseWorker.ts` — wire up `uberCache` and `healTargetCache` data from WASM parser
  - **Modified:** `DemoViewer.tsx` — mount the panel in the UI layer
  - **Modified:** `SettingsPanel.tsx` — add killfeed seek buffer slider
  - **Modified:** `store.ts` / `types.ts` — new `MatchKillfeed` panel type and `killfeedSeekBuffer` setting
  - **Modified:** `AboutPanel.tsx` / `SettingsPanel.tsx` — close killfeed panel when opening other panels

  ## Test plan
  - [ ] Load a demo and confirm the panel toggle button appears on the left side
  - [ ] Open the panel and verify all kills are listed with correct timestamps, names, weapon icons, and team colors
  - [ ] Type a player name in the filter and verify the list filters correctly
  - [ ] Click a row and verify playback seeks to that tick and jumps to POV
  - [ ] Verify uber pop events appear in the list with correct medic names
  - [ ] Test the killfeed seek buffer slider in settings