### PR TITLE
Add draggable 3D stickers to map playback controls

### DIFF
--- a/src/components/Controls/SpectatorControls.js
+++ b/src/components/Controls/SpectatorControls.js
@@ -47,6 +47,7 @@ export class SpectatorControls {
     this.sprintMultiplier = SPRINTMULT
     this.keyMapping = Object.assign({}, KEYMAPPING, KEYMAPPING)
     this.enabled = false
+    this.allowPointerLock = true
     this.lastEscFromPointerLock = 0
     this._mouseState = { x: 0, y: 0 }
     this._keyState = { press: 0, prevPress: 0 }
@@ -73,6 +74,7 @@ export class SpectatorControls {
   }
   _processMouseDownEvent(event) {
     if (event.button === MOUSEMAPPING.LEFT) {
+      if (!this.allowPointerLock) return null
       const timeSinceLastEsc = performance.now() - this.lastEscFromPointerLock
       if (timeSinceLastEsc <= ESCLOCKDELAY) return null
       this.enable()
@@ -139,6 +141,7 @@ export class SpectatorControls {
     document.removeEventListener('pointerlockchange', this._processPointerLockChangeEvent)
   }
   enable() {
+    if (!this.allowPointerLock) return null
     if (this.isEnabled()) return null
     document.addEventListener('mousemove', this._processMouseMoveEvent)
     document.addEventListener('keydown', this._processKeyEvent)

--- a/src/components/DemoViewer.tsx
+++ b/src/components/DemoViewer.tsx
@@ -18,6 +18,7 @@ import { Actors } from '@components/Scene/Actors'
 import { Projectiles } from '@components/Scene/Projectiles'
 import { World } from '@components/Scene/World'
 import { Skybox } from '@components/Scene/Skybox'
+import { Stickers } from '@components/Scene/Stickers'
 import { AsyncParser } from './Analyse/Data/AsyncParser'
 import { CachedPlayer } from './Analyse/Data/PlayerCache'
 import { InterpolatedProjectile } from './Scene/Projectiles'
@@ -45,6 +46,7 @@ import { ActorProps } from './Scene/Actors'
 import { isPerfLoggingEnabled, readJsHeapMemoryMb } from '@utils/misc'
 import { useIsMobile } from '@utils/hooks'
 import { cn } from '@utils/styling'
+import { DrawingTool } from '@constants/types'
 
 //
 // ─── THREE SETTINGS & ELEMENTS ──────────────────────────────────────────────────
@@ -68,8 +70,12 @@ const Controls = () => {
   const settings = useStore(state => state.settings)
   const controlsMode = useStore(state => state.scene.controls.mode)
   const bounds = useStore(state => state.scene.bounds)
+  const drawingEnabled = useStore(state => state.drawing.enabled)
+  const drawingTool = useStore(state => state.drawing.tool)
+  const stickerDragActive = useStore(state => state.drawing.stickerDrag.active)
   const focusedObject = useInstance(state => state.focusedObject)
   const lastFocusedPOV = useInstance(state => state.lastFocusedPOV)
+  const isStickersToolActive = drawingEnabled && drawingTool === DrawingTool.STICKERS
 
   // Keep a reference of our scene in the store's instances for easy access
   useEffect(() => {
@@ -129,6 +135,21 @@ const Controls = () => {
     cameraRef.current.far = settings.ui.viewDistance || 15000
     cameraRef.current.updateProjectionMatrix()
   }, [settings.ui.viewDistance])
+
+  useEffect(() => {
+    if (!controlsRef.current) return
+    controlsRef.current.enabled = !stickerDragActive
+  }, [stickerDragActive, controlsMode])
+
+  useEffect(() => {
+    if (!spectatorRef.current) return
+
+    spectatorRef.current.allowPointerLock = !isStickersToolActive
+
+    if (isStickersToolActive && spectatorRef.current.isEnabled()) {
+      spectatorRef.current.disable()
+    }
+  }, [controlsMode, isStickersToolActive])
 
   useFrame(() => {
     if (controlsRef.current) controlsRef.current.update()
@@ -417,6 +438,14 @@ class DemoViewer extends Component<DemoViewerProps> {
   }
 
   onPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (getState().drawing.stickerDrag.active) {
+      return
+    }
+
+    if (getState().drawing.enabled && getState().drawing.tool === DrawingTool.STICKERS) {
+      return
+    }
+
     if (
       Math.abs(event.clientX - this.lastTouchPos.x) < 10 &&
       Math.abs(event.clientY - this.lastTouchPos.y) < 10
@@ -522,6 +551,8 @@ class DemoViewer extends Component<DemoViewerProps> {
           <Suspense fallback={null}>
             <World map={map} mode={settings.scene.mode} />
           </Suspense>
+
+          <Stickers />
 
           {/* Skybox */}
 

--- a/src/components/Misc/DemoDrawing.tsx
+++ b/src/components/Misc/DemoDrawing.tsx
@@ -1,46 +1,35 @@
-import { useRef, useState, useLayoutEffect, CSSProperties } from 'react'
+import { useRef, useLayoutEffect, CSSProperties, useEffect } from 'react'
 import CanvasDraw from 'react-canvas-draw'
 import { motion } from 'framer-motion'
-import * as Tooltip from '@radix-ui/react-tooltip'
 
 import { FaTrashIcon, FaUndoIcon } from './Icons'
 
 import { useStore, useInstance } from '@zus/store'
+import {
+  setDrawingBrushColorAction,
+  setDrawingBrushRadiusAction,
+  setDrawingToolAction,
+} from '@zus/actions'
+import { DrawingTool } from '@constants/types'
+import { BRUSH_COLOR_OPTIONS, BRUSH_RADIUS_OPTIONS } from '@constants/drawing'
 import { cn } from '@utils/styling'
-
-//
-// ─── CONSTANTS ──────────────────────────────────────────────────────────────────
-//
 
 export const TOOLBAR_WIDTH = '450px'
 export const TOOLBAR_HEIGHT = '100px'
-
-export const BRUSH_COLOR_OPTIONS = [
-  { color: '#111111' },
-  { color: '#ffffff' },
-  { color: '#ff0202' },
-  { color: '#0374ff' },
-  { color: '#f800d7' },
-  { color: '#f8a300' },
-  { color: '#40db14' },
-]
-export const BRUSH_RADIUS_OPTIONS = [
-  { label: 'Small', size: 2 },
-  { label: 'Medium', size: 4 },
-  { label: 'Large', size: 9 },
-]
-
-//
-// ─── COMPONENT ──────────────────────────────────────────────────────────────────
-//
 
 export const DemoDrawing = () => {
   const drawingCanvasRef = useRef<CanvasDraw | null>(null)
   const setDrawingCanvas = useInstance(state => state.setDrawingCanvas)
   const enabled = useStore(state => state.drawing.enabled)
+  const drawingTool = useStore(state => state.drawing.tool)
+  const brushColor = useStore(state => state.drawing.brushColor)
+  const brushRadius = useStore(state => state.drawing.brushRadius)
 
-  const [brushColor, setBrushColor] = useState<string>(BRUSH_COLOR_OPTIONS[0].color)
-  const [brushRadius, setBrushRadius] = useState<number>(BRUSH_RADIUS_OPTIONS[1].size)
+  useEffect(() => {
+    if (drawingTool !== DrawingTool.BRUSH) {
+      setDrawingToolAction(DrawingTool.BRUSH)
+    }
+  }, [drawingTool])
 
   const drawingCanvasStyle: CSSProperties = {
     position: 'absolute',
@@ -51,13 +40,14 @@ export const DemoDrawing = () => {
     cursor: enabled ? 'crosshair' : 'auto',
   }
 
-  // Keep a reference to our drawing canvas in "Instance Store" because we
-  // need to be able to call its methods from various places (clear, undo etc.)
   useLayoutEffect(() => {
     if (drawingCanvasRef.current) {
       setDrawingCanvas(drawingCanvasRef.current)
     }
   }, [drawingCanvasRef, setDrawingCanvas])
+
+  const actionButtonClass = () =>
+    'inline-flex h-10 w-10 items-center justify-center rounded-xl bg-white/10 transition-all hover:scale-110 hover:bg-white/20'
 
   return (
     <>
@@ -78,12 +68,12 @@ export const DemoDrawing = () => {
         )}
       >
         <motion.div
-          className="pointer-events-auto flex w-[min(450px,calc(100vw-2rem))] flex-col justify-between rounded-2xl bg-[rgba(50,50,50,0.95)] px-6 pb-4 pt-6 text-white"
+          className="pointer-events-auto flex w-[min(420px,calc(100vw-2rem))] flex-col gap-4 rounded-2xl bg-[rgba(50,50,50,0.95)] px-6 pb-4 pt-5 text-white"
           animate={enabled ? { opacity: 1, y: '-2rem' } : { opacity: 0, y: 100 }}
           transition={{ duration: 0.2 }}
           initial={false}
         >
-          {/* Brush colors */}
+          <div className="text-xs font-bold uppercase tracking-[0.2em] text-white/60">Brush</div>
 
           <div className="flex items-center justify-center">
             {BRUSH_COLOR_OPTIONS.map(({ color }) => (
@@ -95,37 +85,19 @@ export const DemoDrawing = () => {
                   brushColor === color && 'scale-125 [border:3px_solid_white]'
                 )}
                 style={{ backgroundColor: color }}
-                onClick={() => setBrushColor(color)}
+                onClick={() => setDrawingBrushColorAction(color)}
               />
             ))}
           </div>
 
-          <div className="mt-3 flex items-center justify-between">
-            {/* Undo action */}
-
-            <Tooltip.Provider delayDuration={0}>
-              <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <div
-                    className="inline-block cursor-pointer transition-all hover:scale-125"
-                    onClick={drawingCanvasRef.current?.undo}
-                  >
-                    <FaUndoIcon />
-                  </div>
-                </Tooltip.Trigger>
-
-                <Tooltip.Portal>
-                  <Tooltip.Content sideOffset={5}>
-                    <div className="relative rounded-lg bg-pp-panel/90 px-4 py-3">
-                      Undo <kbd className="ml-2">Z</kbd>
-                    </div>
-                    <Tooltip.Arrow />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              </Tooltip.Root>
-            </Tooltip.Provider>
-
-            {/* Brush radiuses */}
+          <div className="flex items-center justify-between">
+            <button
+              className={actionButtonClass()}
+              onClick={() => drawingCanvasRef.current?.undo()}
+              aria-label="Undo brush stroke"
+            >
+              <FaUndoIcon />
+            </button>
 
             <div className="flex items-center justify-center">
               {BRUSH_RADIUS_OPTIONS.map(({ label, size }) => (
@@ -136,37 +108,20 @@ export const DemoDrawing = () => {
                     brushRadius === size && 'font-bold underline',
                     `option ${brushRadius === size ? 'active' : ''}`
                   )}
-                  onClick={() => setBrushRadius(size)}
+                  onClick={() => setDrawingBrushRadiusAction(size)}
                 >
                   {label}
                 </div>
               ))}
             </div>
 
-            {/* Clear action */}
-
-            <Tooltip.Provider delayDuration={0}>
-              <Tooltip.Root>
-                <Tooltip.Trigger asChild>
-                  <div
-                    className="inline-block cursor-pointer transition-all hover:scale-125"
-                    onClick={drawingCanvasRef.current?.clear}
-                  >
-                    <FaTrashIcon className="h-5 w-5" />
-                  </div>
-                </Tooltip.Trigger>
-
-                <Tooltip.Portal>
-                  <Tooltip.Content sideOffset={5}>
-                    <div className="relative rounded-lg bg-pp-panel/90 px-4 py-3">
-                      Clear <kbd className="ml-2">C</kbd>
-                    </div>
-
-                    <Tooltip.Arrow />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              </Tooltip.Root>
-            </Tooltip.Provider>
+            <button
+              className={actionButtonClass()}
+              onClick={() => drawingCanvasRef.current?.clear()}
+              aria-label="Clear brush strokes"
+            >
+              <FaTrashIcon className="h-5 w-5" />
+            </button>
           </div>
         </motion.div>
       </div>

--- a/src/components/Misc/GlobalKeyHandler.tsx
+++ b/src/components/Misc/GlobalKeyHandler.tsx
@@ -2,7 +2,16 @@ import { useRef, useCallback } from 'react'
 import keycode from 'keycode'
 
 import { useStore, useInstance } from '@zus/store'
-import { popUIPanelAction, toggleUIDrawingAction } from '@zus/actions'
+import {
+  clearStickersAction,
+  deleteSelectedStickerAction,
+  popUIPanelAction,
+  redoStickersAction,
+  setStickersPanelOpenAction,
+  toggleUIDrawingAction,
+  undoStickersAction,
+} from '@zus/actions'
+import { DrawingTool } from '@constants/types'
 
 import { useEventListener } from '@utils/hooks'
 
@@ -14,6 +23,7 @@ export const GlobalKeyHandler = () => {
   const keysHeld = useRef(new Map())
 
   const settings = useStore(state => state.settings)
+  const drawing = useStore(state => state.drawing)
   const drawingCanvas = useInstance(state => state.drawingCanvas)
   const activePanels = useStore(state => state.ui.activePanels)
 
@@ -22,10 +32,13 @@ export const GlobalKeyHandler = () => {
       try {
         switch (keycode(event)) {
           case 'esc':
-            popUIPanelAction()
-            if (activePanels.length === 0) {
+            if (activePanels.length > 0) {
+              popUIPanelAction()
+            } else if (drawing.enabled) {
               // Also support dismissing the drawing UI by using Esc key
               toggleUIDrawingAction(false)
+            } else if (drawing.stickersPanelOpen) {
+              setStickersPanelOpenAction(false)
             }
             break
 
@@ -36,19 +49,42 @@ export const GlobalKeyHandler = () => {
             toggleUIDrawingAction()
             break
 
+          case 'g':
+            if (keysHeld.current.has('g')) return null
+            keysHeld.current.set('g', true)
+            setStickersPanelOpenAction(!drawing.stickersPanelOpen)
+            break
+
           case 'c':
-            if (drawingCanvas) drawingCanvas.clear()
+            if (drawing.enabled && drawing.tool === DrawingTool.BRUSH) {
+              drawingCanvas?.clear()
+            } else if (drawing.stickersPanelOpen) {
+              clearStickersAction()
+            }
             break
 
           case 'z':
-            if (drawingCanvas) drawingCanvas.undo()
+            if (drawing.enabled && drawing.tool === DrawingTool.BRUSH) {
+              drawingCanvas?.undo()
+            } else if (drawing.stickersPanelOpen && event.shiftKey) {
+              redoStickersAction()
+            } else if (drawing.stickersPanelOpen) {
+              undoStickersAction()
+            }
+            break
+
+          case 'backspace':
+          case 'delete':
+            if (drawing.selectedStickerId) {
+              deleteSelectedStickerAction()
+            }
             break
         }
       } catch (error) {
         console.error(error)
       }
     },
-    [drawingCanvas, activePanels] // eslint-disable-line react-hooks/exhaustive-deps
+    [activePanels, drawing, drawingCanvas] // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   const canvasKeyUp = useCallback(
@@ -59,6 +95,10 @@ export const GlobalKeyHandler = () => {
           if (settings.drawing.activation === 'hold') {
             toggleUIDrawingAction(false)
           }
+          break
+
+        case 'g':
+          keysHeld.current.delete('g')
           break
       }
     },

--- a/src/components/Misc/Icons.tsx
+++ b/src/components/Misc/Icons.tsx
@@ -146,6 +146,64 @@ export const FaUndoIcon = (props: SVGProps<SVGSVGElement>) => {
   )
 }
 
+export const FaRedoIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      viewBox="0 0 512 512"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M299.667 224.333H500c6.627 0 12-5.373 12-12V12c0-6.627-5.373-12-12-12h-48c-6.627 0-12 5.373-12 12v78.112C394.227 39.279 327.74 7.47 253.825 8.007 116.919 9.001 7.377 119.63 7.668 256.539 7.959 393.258 118.88 504 255.667 504c64.089 0 122.496-24.313 166.51-64.215 5.099-4.622 5.334-12.554.467-17.42l-33.967-33.967c-4.474-4.474-11.662-4.717-16.401-.525C341.24 415.336 300.42 432 255.667 432c-97.268 0-176-78.716-176-176 0-97.267 78.716-176 176-176 58.496 0 110.28 28.476 142.274 72.333h-98.274c-6.627 0-12 5.373-12 12v48c0 6.627 5.373 12 12 12z"></path>
+    </svg>
+  )
+}
+
+export const BrushToolIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M14.5 4.5 19.5 9.5M8.5 20.5c-1.933 0-3.5-1.567-3.5-3.5 0-1.2.6-2.1 1.8-2.7.9-.4 1.6-1.1 2-2l6.4-6.4a1.414 1.414 0 0 1 2 0l2.9 2.9a1.414 1.414 0 0 1 0 2l-6.4 6.4c-.9.4-1.6 1.1-2 2-.6 1.2-1.5 1.8-2.7 1.8Z"
+      />
+    </svg>
+  )
+}
+
+export const StickerToolIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="none"
+      viewBox="0 0 24 24"
+      height="1rem"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M2 12C2 17.5228 6.47715 22 12 22C12.6477 22 13.2503 21.7004 13.7083 21.2424L21.2424 13.7083C21.7004 13.2503 22 12.6477 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12Z" />
+      <path d="M12 17C10.8846 17 9.85038 16.6303 9 16" strokeLinecap="round" />
+      <ellipse cx="15" cy="10.5" rx="1" ry="1.5" fill="currentColor" />
+      <ellipse cx="9" cy="10.5" rx="1" ry="1.5" fill="currentColor" />
+      <path d="M12 22C12 19.2071 12 17.8107 12.3928 16.688C13.0964 14.6773 14.6773 13.0964 16.688 12.3928C17.8107 12 19.2071 12 22 12" />
+    </svg>
+  )
+}
+
 export const HiListBulletIcon = (props: SVGProps<SVGSVGElement>) => {
   return (
     <svg
@@ -270,7 +328,10 @@ export const BsBookmarkFillIcon = (props: SVGProps<SVGSVGElement>) => {
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <path fillRule="evenodd" d="M2 15.5V2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.74.439L8 13.069l-5.26 2.87A.5.5 0 0 1 2 15.5"></path>
+      <path
+        fillRule="evenodd"
+        d="M2 15.5V2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v13.5a.5.5 0 0 1-.74.439L8 13.069l-5.26 2.87A.5.5 0 0 1 2 15.5"
+      ></path>
     </svg>
   )
 }

--- a/src/components/Scene/Stickers.tsx
+++ b/src/components/Scene/Stickers.tsx
@@ -1,0 +1,778 @@
+import { useEffect, useMemo, useRef, type MutableRefObject } from 'react'
+
+import * as THREE from 'three'
+import { useFrame, useLoader, useThree } from '@react-three/fiber'
+
+import classIconsAtlasUrl from '@assets/class_icons_64.png'
+import { useStore, getState, useInstance } from '@zus/store'
+import {
+  addStickerAction,
+  cancelStickerDragAction,
+  moveStickerAction,
+  selectStickerAction,
+  startStickerDragAction,
+} from '@zus/actions'
+import { CLASS_ORDER_MAP } from '@constants/mappings'
+import { ControlsMode, StickerTeam } from '@constants/types'
+import { useIsMobile } from '@utils/hooks'
+
+const STICKER_GROUP_NAME = 'stickers'
+const STICKER_MARKER_NAME = 'sticker-marker'
+const IS_FIXED_SIZE = true
+const STICKER_FIXED_SCREEN_SIZE_PX = 45
+const STICKER_MARKER_SIZE_MIN = 60
+const STICKER_MARKER_SIZE_MAX = 100
+const STICKER_MARKER_SIZE_FACTOR = 0.045
+const STICKER_WORLD_OFFSET = 4
+const STICKER_DRAG_COMMIT_DISTANCE_PX = 10
+const STICKER_RING_ANIMATION_SPEED = 12
+const STICKER_RING_SCALE_MIN = 1.1
+const STICKER_RING_SCALE_MAX = 1.45
+
+const STICKER_TEAM_COLORS: Record<StickerTeam, string> = {
+  red: '#cf4a2e',
+  blue: '#5885a2',
+}
+
+const STICKER_CLASS_IDS = Object.entries(CLASS_ORDER_MAP)
+  .filter(([classId]) => classId !== '0')
+  .sort(([, leftOrder], [, rightOrder]) => leftOrder - rightOrder)
+  .map(([classId]) => Number(classId))
+
+type SurfaceHit = {
+  position: [number, number, number]
+}
+
+type SceneStickerProps = {
+  stickerId?: string
+  position: [number, number, number]
+  texture?: THREE.Texture
+  selected?: boolean
+  preview?: boolean
+  dragged?: boolean
+  ringTexture: THREE.Texture
+  dragPreviewPositionRef?: MutableRefObject<THREE.Vector3 | null>
+}
+
+export const Stickers = () => {
+  const { camera, gl, scene } = useThree()
+  const isMobile = useIsMobile()
+
+  const controlsMode = useStore(state => state.scene.controls.mode)
+  const stickers = useStore(state => state.drawing.stickerHistory.present)
+  const stickerDrag = useStore(state => state.drawing.stickerDrag)
+  const selectedStickerId = useStore(state => state.drawing.selectedStickerId)
+
+  const classIconsAtlas = useLoader(THREE.TextureLoader, classIconsAtlasUrl)
+  const stickerTextures = useMemo(
+    () => createStickerTextureMap(classIconsAtlas.image as HTMLImageElement),
+    [classIconsAtlas.image]
+  )
+  const ringTexture = useMemo(() => createStickerRingTexture(), [])
+  const dragCursorRef = useRef<{ screenX: number; screenY: number } | null>(null)
+  const dragPreviewPositionRef = useRef<THREE.Vector3 | null>(null)
+  const dragPlaneRef = useRef<THREE.Plane | null>(null)
+  const dragRaycasterRef = useRef(new THREE.Raycaster())
+  const dragPointerRef = useRef(new THREE.Vector2())
+  const dragPlaneNormalRef = useRef(new THREE.Vector3())
+  const dragPlaneAnchorRef = useRef(new THREE.Vector3())
+  const dragPlaneIntersectionRef = useRef(new THREE.Vector3())
+
+  if (isMobile) {
+    return null
+  }
+
+  const interactionEnabled =
+    controlsMode === ControlsMode.RTS || controlsMode === ControlsMode.SPECTATOR
+
+  useEffect(() => {
+    if (!interactionEnabled || stickerDrag.active) return
+
+    const handlePointerDownCapture = (event: PointerEvent) => {
+      if (event.button !== 0) return
+      if (isStickerPanelPointerEvent(event)) return
+
+      const stickerId = isSceneCanvasPointerEvent(event, gl.domElement)
+        ? getStickerIdFromScreen({
+            camera,
+            domElement: gl.domElement,
+            scene,
+            screenX: event.clientX,
+            screenY: event.clientY,
+          })
+        : null
+
+      if (!stickerId) {
+        if (selectedStickerId) {
+          selectStickerAction(undefined)
+        }
+        return
+      }
+
+      const currentControls = (useInstance.getState().threeScene as any).controls
+      if (currentControls) {
+        currentControls.enabled = false
+      }
+
+      event.preventDefault()
+      event.stopImmediatePropagation()
+
+      selectStickerAction(stickerId)
+      startStickerDragAction({
+        kind: 'move',
+        stickerId,
+        screenX: event.clientX,
+        screenY: event.clientY,
+      })
+    }
+
+    window.addEventListener('pointerdown', handlePointerDownCapture, true)
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDownCapture, true)
+    }
+  }, [camera, gl, interactionEnabled, scene, selectedStickerId, stickerDrag.active])
+
+  useEffect(() => {
+    if (!interactionEnabled || !stickerDrag.active) return
+
+    const currentControls = (useInstance.getState().threeScene as any).controls
+    if (currentControls) {
+      currentControls.enabled = false
+    }
+
+    dragCursorRef.current = {
+      screenX: stickerDrag.screenX,
+      screenY: stickerDrag.screenY,
+    }
+
+    if (stickerDrag.kind === 'move' && stickerDrag.stickerId) {
+      const draggedSticker = stickers.find(sticker => sticker.id === stickerDrag.stickerId)
+
+      if (draggedSticker) {
+        dragPreviewPositionRef.current = new THREE.Vector3(...draggedSticker.position)
+        initializeDragPlane(
+          camera,
+          dragPreviewPositionRef.current,
+          dragPlaneRef,
+          dragPlaneNormalRef,
+          dragPlaneAnchorRef
+        )
+      }
+    } else {
+      dragPreviewPositionRef.current = null
+      dragPlaneRef.current = null
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      dragCursorRef.current = {
+        screenX: event.clientX,
+        screenY: event.clientY,
+      }
+    }
+
+    const handlePointerUp = () => {
+      const currentDrag = getState().drawing.stickerDrag
+      const currentCursor = dragCursorRef.current
+      const hasCommittedDrag =
+        currentCursor &&
+        hasExceededStickerDragThreshold(
+          currentDrag.screenX,
+          currentDrag.screenY,
+          currentCursor.screenX,
+          currentCursor.screenY
+        )
+
+      if (!hasCommittedDrag) {
+        cancelStickerDragAction()
+        return
+      }
+
+      const currentHit = currentCursor
+        ? getSurfaceHitFromScreen({
+            camera,
+            domElement: gl.domElement,
+            scene,
+            screenX: currentCursor.screenX,
+            screenY: currentCursor.screenY,
+            raycaster: dragRaycasterRef.current,
+            pointer: dragPointerRef.current,
+          })
+        : null
+
+      if (currentHit) {
+        if (
+          currentDrag.kind === 'create' &&
+          currentDrag.stickerClassId &&
+          currentDrag.stickerTeam
+        ) {
+          addStickerAction({
+            id: createStickerId(),
+            position: currentHit.position,
+            classId: currentDrag.stickerClassId,
+            team: currentDrag.stickerTeam,
+          })
+        }
+
+        if (currentDrag.kind === 'move' && currentDrag.stickerId) {
+          moveStickerAction(currentDrag.stickerId, currentHit.position)
+        }
+      }
+
+      cancelStickerDragAction()
+    }
+
+    const handlePointerCancel = () => {
+      cancelStickerDragAction()
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerCancel)
+
+    return () => {
+      dragCursorRef.current = null
+      dragPreviewPositionRef.current = null
+      dragPlaneRef.current = null
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('pointercancel', handlePointerCancel)
+    }
+  }, [
+    camera,
+    gl,
+    interactionEnabled,
+    scene,
+    stickerDrag.active,
+    stickerDrag.kind,
+    stickerDrag.screenX,
+    stickerDrag.screenY,
+    stickerDrag.stickerId,
+    stickers,
+  ])
+
+  useFrame(() => {
+    if (!interactionEnabled || !stickerDrag.active || !dragCursorRef.current) return
+
+    const { screenX, screenY } = dragCursorRef.current
+    const hasCommittedDrag = hasExceededStickerDragThreshold(
+      stickerDrag.screenX,
+      stickerDrag.screenY,
+      screenX,
+      screenY
+    )
+
+    if (!hasCommittedDrag) return
+
+    const raycasterReady = setRaycasterFromScreen({
+      camera,
+      domElement: gl.domElement,
+      screenX,
+      screenY,
+      raycaster: dragRaycasterRef.current,
+      pointer: dragPointerRef.current,
+    })
+
+    if (!raycasterReady) return
+
+    if (!dragPlaneRef.current) {
+      const initialHit = getSurfaceHitFromScreen({
+        camera,
+        domElement: gl.domElement,
+        scene,
+        screenX,
+        screenY,
+        raycaster: dragRaycasterRef.current,
+        pointer: dragPointerRef.current,
+      })
+
+      if (!initialHit) return
+
+      dragPreviewPositionRef.current = new THREE.Vector3(...initialHit.position)
+      initializeDragPlane(
+        camera,
+        dragPreviewPositionRef.current,
+        dragPlaneRef,
+        dragPlaneNormalRef,
+        dragPlaneAnchorRef
+      )
+    }
+
+    if (!dragPlaneRef.current) return
+
+    const intersection = dragRaycasterRef.current.ray.intersectPlane(
+      dragPlaneRef.current,
+      dragPlaneIntersectionRef.current
+    )
+
+    if (!intersection) return
+
+    if (!dragPreviewPositionRef.current) {
+      dragPreviewPositionRef.current = intersection.clone()
+    } else {
+      dragPreviewPositionRef.current.copy(intersection)
+    }
+  })
+
+  const previewTexture =
+    stickerDrag.stickerClassId && stickerDrag.stickerTeam
+      ? stickerTextures[getStickerTextureKey(stickerDrag.stickerClassId, stickerDrag.stickerTeam)]
+      : undefined
+
+  return (
+    <group name={STICKER_GROUP_NAME}>
+      {stickers.map(sticker => (
+        <SceneSticker
+          key={sticker.id}
+          stickerId={sticker.id}
+          texture={stickerTextures[getStickerTextureKey(sticker.classId, sticker.team)]}
+          position={sticker.position}
+          selected={selectedStickerId === sticker.id}
+          dragged={
+            stickerDrag.active &&
+            stickerDrag.kind === 'move' &&
+            stickerDrag.stickerId === sticker.id
+          }
+          ringTexture={ringTexture}
+          dragPreviewPositionRef={dragPreviewPositionRef}
+        />
+      ))}
+
+      {interactionEnabled && stickerDrag.active && stickerDrag.kind === 'create' ? (
+        <SceneSticker
+          texture={previewTexture}
+          position={[0, 0, 0]}
+          preview
+          ringTexture={ringTexture}
+          dragPreviewPositionRef={dragPreviewPositionRef}
+        />
+      ) : null}
+    </group>
+  )
+}
+
+const SceneSticker = ({
+  stickerId,
+  position,
+  texture,
+  selected = false,
+  preview = false,
+  dragged = false,
+  ringTexture,
+  dragPreviewPositionRef,
+}: SceneStickerProps) => {
+  const viewportHeight = useThree(state => state.size.height)
+  const groupRef = useRef<THREE.Group>(null)
+  const markerMaterialRef = useRef<THREE.SpriteMaterial>(null)
+  const ringMaterialRef = useRef<THREE.SpriteMaterial>(null)
+  const hitMaterialRef = useRef<THREE.SpriteMaterial>(null)
+  const markerSpriteRef = useRef<THREE.Sprite>(null)
+  const ringSpriteRef = useRef<THREE.Sprite>(null)
+  const hitSpriteRef = useRef<THREE.Sprite>(null)
+  const cameraPositionRef = useRef(new THREE.Vector3())
+  const stickerPositionRef = useRef(new THREE.Vector3())
+  const basePositionRef = useRef(new THREE.Vector3(...position))
+  const targetPositionRef = useRef(new THREE.Vector3(...position))
+  const ringSelectionProgressRef = useRef(selected ? 1 : 0)
+
+  useEffect(() => {
+    basePositionRef.current.set(position[0], position[1], position[2])
+    targetPositionRef.current.set(position[0], position[1], position[2])
+
+    if (!dragged && groupRef.current) {
+      groupRef.current.position.copy(basePositionRef.current)
+    }
+  }, [dragged, position])
+
+  useEffect(() => {
+    if (markerMaterialRef.current) {
+      markerMaterialRef.current.map = texture ?? null
+      markerMaterialRef.current.needsUpdate = true
+    }
+  }, [texture])
+
+  useFrame(({ camera }, delta) => {
+    if (
+      !groupRef.current ||
+      !markerMaterialRef.current ||
+      !ringMaterialRef.current ||
+      !hitMaterialRef.current ||
+      !markerSpriteRef.current ||
+      !ringSpriteRef.current ||
+      !hitSpriteRef.current ||
+      !texture
+    ) {
+      return
+    }
+
+    const dragPosition = dragPreviewPositionRef?.current
+
+    if ((dragged || preview) && dragPosition) {
+      targetPositionRef.current.copy(dragPosition)
+      groupRef.current.visible = true
+      groupRef.current.position.copy(targetPositionRef.current)
+    } else if (preview) {
+      groupRef.current.visible = false
+    } else {
+      groupRef.current.visible = true
+    }
+
+    camera.getWorldPosition(cameraPositionRef.current)
+    groupRef.current.getWorldPosition(stickerPositionRef.current)
+
+    const distance = cameraPositionRef.current.distanceTo(stickerPositionRef.current)
+    const markerSize = IS_FIXED_SIZE
+      ? getWorldSpaceSizeForScreenPixels(
+          camera,
+          viewportHeight,
+          STICKER_FIXED_SCREEN_SIZE_PX,
+          distance
+        )
+      : THREE.MathUtils.clamp(
+          distance * STICKER_MARKER_SIZE_FACTOR,
+          STICKER_MARKER_SIZE_MIN,
+          STICKER_MARKER_SIZE_MAX
+        )
+
+    markerSpriteRef.current.scale.set(markerSize, markerSize, 1)
+    hitSpriteRef.current.scale.set(markerSize * 1.35, markerSize * 1.35, 1)
+
+    ringSelectionProgressRef.current = THREE.MathUtils.damp(
+      ringSelectionProgressRef.current,
+      selected ? 1 : 0,
+      STICKER_RING_ANIMATION_SPEED,
+      delta
+    )
+
+    const ringScaleMultiplier = THREE.MathUtils.lerp(
+      STICKER_RING_SCALE_MIN,
+      STICKER_RING_SCALE_MAX,
+      ringSelectionProgressRef.current
+    )
+    ringSpriteRef.current.scale.set(
+      markerSize * ringScaleMultiplier,
+      markerSize * ringScaleMultiplier,
+      1
+    )
+
+    if (preview) {
+      markerMaterialRef.current.opacity = 0.9
+      ringMaterialRef.current.opacity = 0
+      hitMaterialRef.current.opacity = 0
+      return
+    }
+
+    markerMaterialRef.current.opacity = 1
+    ringMaterialRef.current.opacity = ringSelectionProgressRef.current
+    hitMaterialRef.current.opacity = 0.001
+  })
+
+  return (
+    <group ref={groupRef} userData={{ stickerId }}>
+      <sprite ref={hitSpriteRef} name="sticker-hit-area" userData={{ stickerId }}>
+        <spriteMaterial
+          ref={hitMaterialRef}
+          map={texture ?? null}
+          color="#ffffff"
+          transparent
+          depthTest={false}
+          depthWrite={false}
+          opacity={0.001}
+        />
+      </sprite>
+
+      <sprite ref={ringSpriteRef} name="sticker-ring" userData={{ stickerId }}>
+        <spriteMaterial
+          ref={ringMaterialRef}
+          map={ringTexture}
+          color="#FFC800"
+          transparent
+          depthTest={false}
+          depthWrite={false}
+          opacity={selected ? 1 : 0}
+        />
+      </sprite>
+
+      <sprite ref={markerSpriteRef} name={STICKER_MARKER_NAME} userData={{ stickerId }}>
+        <spriteMaterial
+          ref={markerMaterialRef}
+          map={texture ?? null}
+          color="#ffffff"
+          transparent
+          depthTest={false}
+          depthWrite={false}
+          opacity={preview ? 0.9 : 1}
+        />
+      </sprite>
+    </group>
+  )
+}
+
+function createStickerTextureMap(image: HTMLImageElement): Record<string, THREE.Texture> {
+  const textures: Record<string, THREE.Texture> = {}
+  const sliceSize = image.width
+
+  STICKER_CLASS_IDS.forEach(classId => {
+    const classIndex = CLASS_ORDER_MAP[classId]
+
+    ;(['red', 'blue'] as StickerTeam[]).forEach(team => {
+      const canvas = document.createElement('canvas')
+      canvas.width = 128
+      canvas.height = 128
+
+      const context = canvas.getContext('2d')
+      if (!context) return
+
+      context.clearRect(0, 0, canvas.width, canvas.height)
+      context.translate(64, 64)
+
+      context.beginPath()
+      context.arc(0, 0, 56, 0, Math.PI * 2)
+      context.fillStyle = STICKER_TEAM_COLORS[team]
+      context.fill()
+
+      context.beginPath()
+      context.arc(0, 0, 56, 0, Math.PI * 2)
+      context.strokeStyle = '#ffffff'
+      context.lineWidth = 10
+      context.stroke()
+
+      context.beginPath()
+      context.arc(0, 0, 48, 0, Math.PI * 2)
+      context.fillStyle = 'rgba(15, 18, 24, 0.12)'
+      context.fill()
+
+      context.save()
+      context.beginPath()
+      context.arc(0, 0, 47, 0, Math.PI * 2)
+      context.clip()
+      context.drawImage(image, 0, classIndex * sliceSize, sliceSize, sliceSize, -38, -38, 76, 76)
+      context.restore()
+
+      const texture = new THREE.CanvasTexture(canvas)
+      texture.colorSpace = THREE.SRGBColorSpace
+      texture.needsUpdate = true
+      textures[getStickerTextureKey(classId, team)] = texture
+    })
+  })
+
+  return textures
+}
+
+function createStickerRingTexture(): THREE.Texture {
+  const canvas = document.createElement('canvas')
+  canvas.width = 128
+  canvas.height = 128
+
+  const context = canvas.getContext('2d')
+  if (!context) return new THREE.Texture()
+
+  context.clearRect(0, 0, canvas.width, canvas.height)
+  context.translate(64, 64)
+  context.beginPath()
+  context.arc(0, 0, 56, 0, Math.PI * 2)
+  context.strokeStyle = '#ffffff'
+  context.lineWidth = 10
+  context.stroke()
+
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.colorSpace = THREE.SRGBColorSpace
+  texture.needsUpdate = true
+  return texture
+}
+
+function getStickerTextureKey(classId: number, team: StickerTeam): string {
+  return `${team}-${classId}`
+}
+
+function getSurfaceHitFromScreen({
+  camera,
+  domElement,
+  scene,
+  screenX,
+  screenY,
+  raycaster,
+  pointer,
+}: {
+  camera: THREE.Camera
+  domElement: HTMLCanvasElement
+  scene: THREE.Scene
+  screenX: number
+  screenY: number
+  raycaster?: THREE.Raycaster
+  pointer?: THREE.Vector2
+}): SurfaceHit | null {
+  const rect = domElement.getBoundingClientRect()
+  if (screenX < rect.left || screenX > rect.right || screenY < rect.top || screenY > rect.bottom) {
+    return null
+  }
+
+  const world = scene.getObjectByName('world')
+  if (!world) return null
+
+  const nextPointer = pointer ?? new THREE.Vector2()
+  nextPointer.set(
+    ((screenX - rect.left) / rect.width) * 2 - 1,
+    -((screenY - rect.top) / rect.height) * 2 + 1
+  )
+
+  const nextRaycaster = raycaster ?? new THREE.Raycaster()
+  nextRaycaster.setFromCamera(nextPointer, camera)
+
+  const intersections = nextRaycaster.intersectObject(world, true)
+  const intersection = intersections.find(item => item.object.visible)
+
+  if (!intersection) return null
+
+  const point = intersection.point.clone()
+  if (intersection.face) {
+    const worldNormal = intersection.face.normal
+      .clone()
+      .transformDirection(intersection.object.matrixWorld)
+      .normalize()
+    point.addScaledVector(worldNormal, STICKER_WORLD_OFFSET)
+  }
+
+  return {
+    position: [point.x, point.y, point.z],
+  }
+}
+
+function initializeDragPlane(
+  camera: THREE.Camera,
+  anchor: THREE.Vector3,
+  planeRef: MutableRefObject<THREE.Plane | null>,
+  normalRef: MutableRefObject<THREE.Vector3>,
+  anchorRef: MutableRefObject<THREE.Vector3>
+) {
+  camera.getWorldDirection(normalRef.current)
+  anchorRef.current.copy(anchor)
+  planeRef.current = new THREE.Plane().setFromNormalAndCoplanarPoint(
+    normalRef.current,
+    anchorRef.current
+  )
+}
+
+function setRaycasterFromScreen({
+  camera,
+  domElement,
+  screenX,
+  screenY,
+  raycaster,
+  pointer,
+}: {
+  camera: THREE.Camera
+  domElement: HTMLCanvasElement
+  screenX: number
+  screenY: number
+  raycaster: THREE.Raycaster
+  pointer: THREE.Vector2
+}): boolean {
+  const rect = domElement.getBoundingClientRect()
+  if (screenX < rect.left || screenX > rect.right || screenY < rect.top || screenY > rect.bottom) {
+    return false
+  }
+
+  pointer.set(
+    ((screenX - rect.left) / rect.width) * 2 - 1,
+    -((screenY - rect.top) / rect.height) * 2 + 1
+  )
+  raycaster.setFromCamera(pointer, camera)
+
+  return true
+}
+
+function getStickerIdFromScreen({
+  camera,
+  domElement,
+  scene,
+  screenX,
+  screenY,
+}: {
+  camera: THREE.Camera
+  domElement: HTMLCanvasElement
+  scene: THREE.Scene
+  screenX: number
+  screenY: number
+}): string | null {
+  const rect = domElement.getBoundingClientRect()
+  if (screenX < rect.left || screenX > rect.right || screenY < rect.top || screenY > rect.bottom) {
+    return null
+  }
+
+  const stickerGroup = scene.getObjectByName(STICKER_GROUP_NAME)
+  if (!stickerGroup) return null
+
+  const pointer = new THREE.Vector2(
+    ((screenX - rect.left) / rect.width) * 2 - 1,
+    -((screenY - rect.top) / rect.height) * 2 + 1
+  )
+
+  const raycaster = new THREE.Raycaster()
+  raycaster.setFromCamera(pointer, camera)
+
+  const intersections = raycaster.intersectObject(stickerGroup, true)
+  const stickerIntersection = intersections.find(intersection =>
+    resolveStickerId(intersection.object)
+  )
+
+  return stickerIntersection ? resolveStickerId(stickerIntersection.object)! : null
+}
+
+function resolveStickerId(object: THREE.Object3D): string | undefined {
+  if (typeof object.userData.stickerId === 'string') return object.userData.stickerId
+  if (typeof object.parent?.userData.stickerId === 'string') return object.parent.userData.stickerId
+  return undefined
+}
+
+function createStickerId(): string {
+  return `sticker-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function hasExceededStickerDragThreshold(
+  startX: number,
+  startY: number,
+  currentX: number,
+  currentY: number
+): boolean {
+  return Math.hypot(currentX - startX, currentY - startY) >= STICKER_DRAG_COMMIT_DISTANCE_PX
+}
+
+function getWorldSpaceSizeForScreenPixels(
+  camera: THREE.Camera,
+  viewportHeight: number,
+  pixelSize: number,
+  distance: number
+): number {
+  const safeViewportHeight = Math.max(viewportHeight, 1)
+
+  if ((camera as THREE.PerspectiveCamera).isPerspectiveCamera) {
+    const perspectiveCamera = camera as THREE.PerspectiveCamera
+    const verticalFov = THREE.MathUtils.degToRad(perspectiveCamera.fov)
+    return ((2 * Math.tan(verticalFov / 2) * distance) / safeViewportHeight) * pixelSize
+  }
+
+  if ((camera as THREE.OrthographicCamera).isOrthographicCamera) {
+    const orthographicCamera = camera as THREE.OrthographicCamera
+    return (
+      ((orthographicCamera.top - orthographicCamera.bottom) /
+        orthographicCamera.zoom /
+        safeViewportHeight) *
+      pixelSize
+    )
+  }
+
+  return pixelSize
+}
+
+function isSceneCanvasPointerEvent(event: PointerEvent, sceneCanvas: HTMLCanvasElement): boolean {
+  const target = event.target
+
+  if (target === sceneCanvas) return true
+  return target instanceof HTMLCanvasElement
+}
+
+function isStickerPanelPointerEvent(event: PointerEvent): boolean {
+  const target = event.target
+  return target instanceof Element && !!target.closest('[data-sticker-panel="true"]')
+}

--- a/src/components/UI/PlaybackPanel.tsx
+++ b/src/components/UI/PlaybackPanel.tsx
@@ -11,11 +11,19 @@ import {
   IoMdPlayIcon,
   BsBookmarkIcon,
   BsBookmarkFillIcon,
+  StickerToolIcon,
 } from '@components/Misc/Icons'
 import { EventHistoryText } from './EventHistoryText'
+import { StickerPalette } from './StickerPalette'
 
 import { useInstance, useStore } from '@zus/store'
-import { goToTickAction, togglePlaybackAction, changePlaySpeedAction, toggleBookmarkAction } from '@zus/actions'
+import {
+  changePlaySpeedAction,
+  goToTickAction,
+  setStickersPanelOpenAction,
+  toggleBookmarkAction,
+  togglePlaybackAction,
+} from '@zus/actions'
 import { focusMainCanvas } from '@utils/misc'
 import { cn } from '@utils/styling'
 import { getDurationFromTicks } from '@utils/parser'
@@ -91,6 +99,8 @@ export const PlaybackPanel = () => {
   const playback = useStore(state => state.playback)
   const bookmarks = useStore(state => state.bookmarks)
   const lastEventHistory = useStore(state => state.eventHistory)?.[0]
+  const stickerDragActive = useStore(state => state.drawing.stickerDrag.active)
+  const stickersOpen = useStore(state => state.drawing.stickersPanelOpen)
   const { playing, speed, tick, maxTicks, forceShowPanel } = playback
   const isBookmarked = bookmarks.includes(tick)
   const isMobile = useIsMobile()
@@ -136,6 +146,10 @@ export const PlaybackPanel = () => {
     focusMainCanvas()
   }
 
+  const toggleStickers = () => {
+    setStickersPanelOpenAction(!stickersOpen)
+  }
+
   return (
     <div className={cn('group relative m-4 max-w-full rounded-2xl px-6 py-2')}>
       {lastEventHistory && (
@@ -152,192 +166,238 @@ export const PlaybackPanel = () => {
         </div>
       )}
 
-      <div
-        className={cn(
-          'z-20 mt-4 flex items-center justify-center rounded-full px-5 py-3 transition-all duration-500',
-          isMobile ? 'gap-3' : 'gap-6',
-          playing && !forceShowPanel ? 'scale-90 opacity-0 delay-700' : 'bg-black/70 delay-0',
-          'group-hover:scale-100 group-hover:bg-black/70 group-hover:opacity-100 group-hover:delay-0'
+      <div className="relative mt-4 flex justify-center">
+        {!isMobile && (
+          <div className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-4 -translate-x-1/2">
+            <motion.div
+              className="pointer-events-auto"
+              initial={false}
+              animate={
+                stickersOpen ? { opacity: 1, y: 0, scale: 1 } : { opacity: 0, y: 12, scale: 0.96 }
+              }
+              transition={{ duration: 0.18 }}
+            >
+              {stickersOpen ? <StickerPalette /> : null}
+            </motion.div>
+          </div>
         )}
-      >
-        {/* Jump to tick action */}
 
-        {!isMobile && <PlaybackAction
-          mobileTooltipBypass
-          icon={
-            <div className="-mr-1 flex min-w-11 select-none flex-col items-center text-center">
-              <div className="text-xs leading-none">TICK</div>
-              <div className="font-bold leading-none">{tick * 2}</div>
-            </div>
-          }
-          content={
-            <div className="text-center">
-              <div>Jump to tick</div>
-              <form
-                className="relative mt-2 text-black"
-                onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
-                  e.preventDefault()
-                  const tickEl = e.target.elements.namedItem('tick') as HTMLInputElement
-                  const newTick = Number(tickEl.value)
-                  if (isNaN(newTick)) return
-                  goToTick(newTick / 2)
-                }}
-              >
-                <input
-                  type="number"
-                  name="tick"
-                  className="w-28 rounded bg-white py-1 pl-2 pr-7"
-                  placeholder="0"
-                />
-                <button
-                  type="submit"
-                  className="absolute bottom-0 right-0 top-0 ml-2 flex aspect-square items-center justify-center"
-                >
-                  <IoArrowForwardSharpIcon />
-                </button>
-              </form>
+        <div
+          className={cn(
+            'z-20 flex items-center justify-center rounded-full px-5 py-3 transition-all duration-500',
+            isMobile ? 'gap-3' : 'gap-6',
+            playing && !forceShowPanel && !stickersOpen
+              ? 'scale-90 opacity-0 delay-700'
+              : 'bg-black/70 delay-0',
+            'group-hover:scale-100 group-hover:bg-black/70 group-hover:opacity-100 group-hover:delay-0'
+          )}
+        >
+          {/* Jump to tick action */}
 
-              <div className="mt-2 flex justify-between text-xs opacity-80">
-                <div>Total Ticks</div>
-                <div className="font-bold">{maxTicks * 2}</div>
-              </div>
-            </div>
-          }
-        />}
-
-        {/* Jump to start action */}
-
-        <PlaybackAction
-          icon={<AiFillFastForwardIcon width="1.75rem" height="1.75rem" className="rotate-180" />}
-          content={<div>Jump to start</div>}
-          onClick={goToTick.bind(null, 1)}
-        />
-
-        {/* Seek back action */}
-
-        <PlaybackAction
-          icon={<AiFillStepForwardIcon width="1.75rem" height="1.75rem" className="rotate-180" />}
-          content={
-            <div className="grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
-              <div className="col-span-2 text-center">Seek back</div>
-              <div>1 tick</div>
-              <kbd>,</kbd>
-              <div>50 ticks</div>
-              <kbd>←</kbd>
-            </div>
-          }
-          onClick={goToTick.bind(null, tick - 50)}
-        />
-
-        {/* Toggle play / pause action */}
-
-        <PlaybackAction
-          icon={
-            playing ? (
-              <IoMdPauseIcon width="1.75rem" height="1.75rem" />
-            ) : (
-              <IoMdPlayIcon width="1.75rem" height="1.75rem" />
-            )
-          }
-          content={
-            <div>
-              Play / Pause <kbd className="ml-2">Space</kbd>
-            </div>
-          }
-          onClick={togglePlayback}
-        />
-
-        {/* Seek forward action */}
-
-        <PlaybackAction
-          icon={<AiFillStepForwardIcon width="1.75rem" height="1.75rem" />}
-          content={
-            <div className="grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
-              <div className="col-span-2 text-center">Seek forward</div>
-              <div>1 tick</div>
-              <kbd>.</kbd>
-              <div>50 ticks</div>
-              <kbd>→</kbd>
-            </div>
-          }
-          onClick={goToTick.bind(null, tick + 50)}
-        />
-
-        {/* Jump to end action */}
-
-        <PlaybackAction
-          icon={<AiFillFastForwardIcon width="1.75rem" height="1.75rem" />}
-          content={<div>Jump to end</div>}
-          onClick={goToTick.bind(null, maxTicks)}
-        />
-
-        {/* Change play speed action */}
-
-        {!isMobile && <PlaybackAction
-          mobileTooltipBypass
-          icon={
-            <div className="select-none rounded-3xl bg-white/90 px-2 text-sm text-black">
-              {speed}×
-            </div>
-          }
-          content={
-            <>
-              <div className="text-center">Playback speed</div>
-
-              <div
-                className="mt-2 grid gap-1"
-                style={{
-                  gridTemplateColumns: `repeat(${PLAYBACK_SPEED_OPTIONS.length}, minmax(0, 1fr))`,
-                }}
-              >
-                {[...PLAYBACK_SPEED_OPTIONS].reverse().map(({ label, value }) => (
-                  <button
-                    key={`play-speed-option-${label}`}
-                    className={cn(
-                      'flex-1 rounded border border-transparent px-2 py-1 text-center',
-                      'hover:border-white',
-                      value === speed && 'bg-white text-black'
-                    )}
-                    onClick={() => changePlaySpeed(Number(value))}
+          {!isMobile && (
+            <PlaybackAction
+              mobileTooltipBypass
+              icon={
+                <div className="-mr-1 flex min-w-11 select-none flex-col items-center text-center">
+                  <div className="text-xs leading-none">TICK</div>
+                  <div className="font-bold leading-none">{tick * 2}</div>
+                </div>
+              }
+              content={
+                <div className="text-center">
+                  <div>Jump to tick</div>
+                  <form
+                    className="relative mt-2 text-black"
+                    onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
+                      e.preventDefault()
+                      const tickEl = e.target.elements.namedItem('tick') as HTMLInputElement
+                      const newTick = Number(tickEl.value)
+                      if (isNaN(newTick)) return
+                      goToTick(newTick / 2)
+                    }}
                   >
-                    {label}
-                  </button>
-                ))}
-              </div>
+                    <input
+                      type="number"
+                      name="tick"
+                      className="w-28 rounded bg-white py-1 pl-2 pr-7"
+                      placeholder="0"
+                    />
+                    <button
+                      type="submit"
+                      className="absolute bottom-0 right-0 top-0 ml-2 flex aspect-square items-center justify-center"
+                    >
+                      <IoArrowForwardSharpIcon />
+                    </button>
+                  </form>
 
-              <div className="mt-5 grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
-                <div className="flex justify-start">
-                  Increase <kbd className="ml-2">↑</kbd>
+                  <div className="mt-2 flex justify-between text-xs opacity-80">
+                    <div>Total Ticks</div>
+                    <div className="font-bold">{maxTicks * 2}</div>
+                  </div>
                 </div>
+              }
+            />
+          )}
 
-                <div className="flex justify-end">
-                  Decrease <kbd className="ml-2">↓</kbd>
-                </div>
+          {/* Jump to start action */}
+
+          <PlaybackAction
+            icon={<AiFillFastForwardIcon width="1.75rem" height="1.75rem" className="rotate-180" />}
+            content={<div>Jump to start</div>}
+            onClick={goToTick.bind(null, 1)}
+          />
+
+          {/* Seek back action */}
+
+          <PlaybackAction
+            icon={<AiFillStepForwardIcon width="1.75rem" height="1.75rem" className="rotate-180" />}
+            content={
+              <div className="grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
+                <div className="col-span-2 text-center">Seek back</div>
+                <div>1 tick</div>
+                <kbd>,</kbd>
+                <div>50 ticks</div>
+                <kbd>←</kbd>
               </div>
-            </>
-          }
-        />}
+            }
+            onClick={goToTick.bind(null, tick - 50)}
+          />
 
-        {/* Toggle bookmark action */}
+          {/* Toggle play / pause action */}
 
-        <PlaybackAction
-          icon={
-            isBookmarked ? (
-              <BsBookmarkFillIcon width="1.25rem" height="1.25rem" className="text-amber-400" />
-            ) : (
-              <BsBookmarkIcon width="1.25rem" height="1.25rem" />
-            )
-          }
-          content={
-            <div>
-              Toggle bookmark <kbd className="ml-2">B</kbd>
-            </div>
-          }
-          onClick={() => {
-            toggleBookmarkAction()
-            focusMainCanvas()
-          }}
-        />
+          <PlaybackAction
+            icon={
+              playing ? (
+                <IoMdPauseIcon width="1.75rem" height="1.75rem" />
+              ) : (
+                <IoMdPlayIcon width="1.75rem" height="1.75rem" />
+              )
+            }
+            content={
+              <div>
+                Play / Pause <kbd className="ml-2">Space</kbd>
+              </div>
+            }
+            onClick={togglePlayback}
+          />
+
+          {/* Seek forward action */}
+
+          <PlaybackAction
+            icon={<AiFillStepForwardIcon width="1.75rem" height="1.75rem" />}
+            content={
+              <div className="grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
+                <div className="col-span-2 text-center">Seek forward</div>
+                <div>1 tick</div>
+                <kbd>.</kbd>
+                <div>50 ticks</div>
+                <kbd>→</kbd>
+              </div>
+            }
+            onClick={goToTick.bind(null, tick + 50)}
+          />
+
+          {/* Jump to end action */}
+
+          <PlaybackAction
+            icon={<AiFillFastForwardIcon width="1.75rem" height="1.75rem" />}
+            content={<div>Jump to end</div>}
+            onClick={goToTick.bind(null, maxTicks)}
+          />
+
+          {/* Change play speed action */}
+
+          {!isMobile && (
+            <PlaybackAction
+              mobileTooltipBypass
+              icon={
+                <div className="select-none rounded-3xl bg-white/90 px-2 text-sm text-black">
+                  {speed}×
+                </div>
+              }
+              content={
+                <>
+                  <div className="text-center">Playback speed</div>
+
+                  <div
+                    className="mt-2 grid gap-1"
+                    style={{
+                      gridTemplateColumns: `repeat(${PLAYBACK_SPEED_OPTIONS.length}, minmax(0, 1fr))`,
+                    }}
+                  >
+                    {[...PLAYBACK_SPEED_OPTIONS].reverse().map(({ label, value }) => (
+                      <button
+                        key={`play-speed-option-${label}`}
+                        className={cn(
+                          'flex-1 rounded border border-transparent px-2 py-1 text-center',
+                          'hover:border-white',
+                          value === speed && 'bg-white text-black'
+                        )}
+                        onClick={() => changePlaySpeed(Number(value))}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+
+                  <div className="mt-5 grid grid-cols-[auto,auto] gap-x-4 gap-y-1">
+                    <div className="flex justify-start">
+                      Increase <kbd className="ml-2">↑</kbd>
+                    </div>
+
+                    <div className="flex justify-end">
+                      Decrease <kbd className="ml-2">↓</kbd>
+                    </div>
+                  </div>
+                </>
+              }
+            />
+          )}
+
+          {/* Toggle bookmark action */}
+
+          <PlaybackAction
+            icon={
+              isBookmarked ? (
+                <BsBookmarkFillIcon width="1.25rem" height="1.25rem" className="text-amber-400" />
+              ) : (
+                <BsBookmarkIcon width="1.25rem" height="1.25rem" />
+              )
+            }
+            content={
+              <div>
+                Toggle bookmark <kbd className="ml-2">B</kbd>
+              </div>
+            }
+            onClick={() => {
+              toggleBookmarkAction()
+              focusMainCanvas()
+            }}
+          />
+
+          {/* Sticker toggle */}
+
+          {!isMobile && (
+            <PlaybackAction
+              icon={
+                <div
+                  className={cn(
+                    'flex h-9 w-9 items-center justify-center rounded-full transition-all',
+                    (stickersOpen || stickerDragActive) && 'bg-white text-black opacity-100'
+                  )}
+                >
+                  <StickerToolIcon width="1.7rem" height="1.7rem" />
+                </div>
+              }
+              content={
+                <div>
+                  Toggle stickers <kbd className="ml-2">G</kbd>
+                </div>
+              }
+              onClick={toggleStickers}
+            />
+          )}
+        </div>
       </div>
 
       <div className="-ml-[5%] mt-3 w-[110%]">
@@ -352,7 +412,9 @@ export const PlaybackPanel = () => {
             step={1}
             onValueChange={([value]) => goToTick(value)}
           >
-            <Slider.Track className={cn('relative grow rounded-full bg-pp-panel/30', isMobile ? 'h-3' : 'h-2')}>
+            <Slider.Track
+              className={cn('relative grow rounded-full bg-pp-panel/30', isMobile ? 'h-3' : 'h-2')}
+            >
               <Slider.Range className="absolute h-full rounded-full bg-white" />
             </Slider.Track>
           </Slider.Root>

--- a/src/components/UI/SettingsPanel.tsx
+++ b/src/components/UI/SettingsPanel.tsx
@@ -10,7 +10,7 @@ import {
   DotStyleIcon,
 } from '@components/Misc/Icons'
 import { CrosshairStyle } from '@constants/types'
-import { BRUSH_COLOR_OPTIONS } from '@components/Misc/DemoDrawing'
+import { BRUSH_COLOR_OPTIONS } from '@constants/drawing'
 
 import { useStore } from '@zus/store'
 import { toggleUIPanelAction, updateSettingsOptionAction } from '@zus/actions'
@@ -409,8 +409,10 @@ export const SettingsPanel = () => {
           <div className="mb-4 mt-16 text-xs font-black uppercase opacity-60">Drawing</div>
 
           <Option label="Activate" keyCode="F" />
-          <Option label="Clear" keyCode="C" />
-          <Option label="Undo" keyCode="Z" />
+          <Option label="Clear active tool" keyCode="C" />
+          <Option label="Undo active tool" keyCode="Z" />
+          <Option label="Redo stickers" keyCode="Shift + Z" />
+          <Option label="Delete selected sticker" keyCode="Delete" />
 
           <Option label="Activation method" rightClass="col-auto">
             <div className="flex gap-1">

--- a/src/components/UI/StickerPalette.tsx
+++ b/src/components/UI/StickerPalette.tsx
@@ -1,0 +1,135 @@
+import { ClassIcon } from '@components/UI/ClassIcon'
+import { FaRedoIcon, FaTrashIcon, FaUndoIcon } from '@components/Misc/Icons'
+
+import { useStore } from '@zus/store'
+import {
+  clearStickersAction,
+  deleteSelectedStickerAction,
+  redoStickersAction,
+  startStickerDragAction,
+  undoStickersAction,
+} from '@zus/actions'
+import { CLASS_ORDER_MAP } from '@constants/mappings'
+import { StickerTeam } from '@constants/types'
+import { cn } from '@utils/styling'
+
+const STICKER_CLASS_IDS = Object.entries(CLASS_ORDER_MAP)
+  .filter(([classId]) => classId !== '0')
+  .sort(([, leftOrder], [, rightOrder]) => leftOrder - rightOrder)
+  .map(([classId]) => Number(classId))
+
+const STICKER_TEAM_STYLES: Record<StickerTeam, string> = {
+  red: 'bg-[#cf4a2e]/20 border-[#cf4a2e]/70 hover:bg-[#cf4a2e]/30',
+  blue: 'bg-[#5885a2]/20 border-[#5885a2]/70 hover:bg-[#5885a2]/30',
+}
+
+export const StickerPalette = () => {
+  const stickerHistory = useStore(state => state.drawing.stickerHistory)
+  const selectedStickerId = useStore(state => state.drawing.selectedStickerId)
+  const stickerDrag = useStore(state => state.drawing.stickerDrag)
+
+  const handleStartStickerDrag =
+    (classId: number, team: StickerTeam) => (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return
+
+      event.preventDefault()
+
+      startStickerDragAction({
+        kind: 'create',
+        stickerClassId: classId,
+        stickerTeam: team,
+        screenX: event.clientX,
+        screenY: event.clientY,
+      })
+    }
+
+  const actionButtonClass = (enabled: boolean = true) =>
+    cn(
+      'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-white transition-all',
+      enabled ? 'hover:scale-105 hover:bg-white/20' : 'cursor-default opacity-40'
+    )
+
+  return (
+    <div
+      data-sticker-panel="true"
+      className="w-auto rounded-[28px] border border-white/10 bg-black/75 p-4 text-white shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur"
+    >
+      <div className="grid gap-3">
+        {(['blue', 'red'] as StickerTeam[]).map(team => (
+          <div key={`sticker-palette-${team}`} className="flex flex-nowrap gap-2">
+            {STICKER_CLASS_IDS.map(classId => {
+              const isDraggingThisSticker =
+                stickerDrag.active &&
+                stickerDrag.kind === 'create' &&
+                stickerDrag.stickerClassId === classId &&
+                stickerDrag.stickerTeam === team
+
+              return (
+                <button
+                  key={`sticker-palette-${team}-${classId}`}
+                  className={cn(
+                    'cursor-grab rounded-full border p-2 transition-all hover:scale-105 active:scale-95',
+                    STICKER_TEAM_STYLES[team],
+                    isDraggingThisSticker && 'scale-105 cursor-grabbing border-white bg-white/20'
+                  )}
+                  onPointerDown={handleStartStickerDrag(classId, team)}
+                  aria-label={`Drag ${team} class ${classId} sticker`}
+                >
+                  <ClassIcon classId={classId} size={22} />
+                </button>
+              )
+            })}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <div className="text-left text-xs uppercase tracking-[0.1em] text-white/60">
+          Drag & drop onto scene
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            className={actionButtonClass(stickerHistory.past.length > 0)}
+            onClick={() => undoStickersAction()}
+            disabled={stickerHistory.past.length === 0}
+            aria-label="Undo sticker action"
+          >
+            <FaUndoIcon />
+          </button>
+
+          <button
+            className={actionButtonClass(stickerHistory.future.length > 0)}
+            onClick={() => redoStickersAction()}
+            disabled={stickerHistory.future.length === 0}
+            aria-label="Redo sticker action"
+          >
+            <FaRedoIcon />
+          </button>
+
+          <button
+            className={actionButtonClass(!!selectedStickerId)}
+            onClick={() => deleteSelectedStickerAction()}
+            disabled={!selectedStickerId}
+            aria-label="Delete selected sticker"
+          >
+            <FaTrashIcon className="h-4 w-4" />
+          </button>
+
+          <button
+            className={cn(
+              'rounded-full border border-white/10 px-4 py-2 text-sm font-semibold transition-all',
+              stickerHistory.present.length > 0
+                ? 'bg-white/10 hover:bg-white/20'
+                : 'cursor-default bg-white/5 opacity-40'
+            )}
+            onClick={() => clearStickersAction()}
+            disabled={stickerHistory.present.length === 0}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/constants/drawing.ts
+++ b/src/constants/drawing.ts
@@ -1,0 +1,18 @@
+export const BRUSH_COLOR_OPTIONS = [
+  { color: '#111111' },
+  { color: '#ffffff' },
+  { color: '#ff0202' },
+  { color: '#0374ff' },
+  { color: '#f800d7' },
+  { color: '#f8a300' },
+  { color: '#40db14' },
+]
+
+export const BRUSH_RADIUS_OPTIONS = [
+  { label: 'Small', size: 2 },
+  { label: 'Medium', size: 4 },
+  { label: 'Large', size: 9 },
+]
+
+export const DEFAULT_BRUSH_COLOR = BRUSH_COLOR_OPTIONS[0].color
+export const DEFAULT_BRUSH_RADIUS = BRUSH_RADIUS_OPTIONS[1].size

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -29,6 +29,22 @@ export const DrawingActivation = {
 
 export type DrawingActivation = (typeof DrawingActivation)[keyof typeof DrawingActivation]
 
+export const DrawingTool = {
+  BRUSH: 'brush',
+  STICKERS: 'stickers',
+} as const
+
+export type DrawingTool = (typeof DrawingTool)[keyof typeof DrawingTool]
+
+export type StickerTeam = 'red' | 'blue'
+
+export type StickerAnnotation = {
+  id: string
+  position: [number, number, number]
+  classId: number
+  team: StickerTeam
+}
+
 export const UIPanelType = {
   ABOUT: 'About',
   SETTINGS: 'Settings',

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,0 +1,45 @@
+export type HistoryState<T> = {
+  past: T[]
+  present: T
+  future: T[]
+}
+
+export function createHistoryState<T>(present: T): HistoryState<T> {
+  return {
+    past: [],
+    present,
+    future: [],
+  }
+}
+
+export function pushHistoryState<T>(history: HistoryState<T>, present: T): HistoryState<T> {
+  return {
+    past: [...history.past, history.present],
+    present,
+    future: [],
+  }
+}
+
+export function undoHistoryState<T>(history: HistoryState<T>): HistoryState<T> {
+  if (history.past.length === 0) return history
+
+  const previous = history.past[history.past.length - 1]
+
+  return {
+    past: history.past.slice(0, -1),
+    present: previous,
+    future: [history.present, ...history.future],
+  }
+}
+
+export function redoHistoryState<T>(history: HistoryState<T>): HistoryState<T> {
+  if (history.future.length === 0) return history
+
+  const next = history.future[0]
+
+  return {
+    past: [...history.past, history.present],
+    present: next,
+    future: history.future.slice(1),
+  }
+}

--- a/src/zustand/actions.ts
+++ b/src/zustand/actions.ts
@@ -8,7 +8,16 @@ import { PLAYBACK_SPEED_OPTIONS } from '@components/UI/PlaybackPanel'
 
 import { getSceneActors, parseMapBoundaries } from '@utils/scene'
 import { CLASS_ORDER_MAP } from '@constants/mappings'
-import { ControlsMode, Download, SceneMode, UIPanelType } from '@constants/types'
+import {
+  ControlsMode,
+  Download,
+  DrawingTool,
+  SceneMode,
+  StickerAnnotation,
+  StickerTeam,
+  UIPanelType,
+} from '@constants/types'
+import { StickerDragKind } from './drawing'
 
 import { dispatch, getState, initialState, StoreState, useInstance } from './store'
 import { isMobile } from 'react-device-detect'
@@ -473,7 +482,7 @@ export const toggleUIDrawingAction = async (active?: boolean) => {
     const isActive = active !== undefined ? active : !getState().drawing.enabled
 
     if (isActive) {
-      if (document.pointerLockElement) {
+      if (document.pointerLockElement && getState().drawing.tool === DrawingTool.STICKERS) {
         document.exitPointerLock()
       }
 
@@ -488,6 +497,138 @@ export const toggleUIDrawingAction = async (active?: boolean) => {
         drawingCanvas?.clear()
       }
     }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const setDrawingToolAction = async (tool: DrawingTool) => {
+  try {
+    if (tool === DrawingTool.STICKERS && document.pointerLockElement) {
+      document.exitPointerLock()
+    }
+
+    dispatch({ type: 'SET_DRAWING_TOOL', payload: tool })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const setDrawingBrushColorAction = async (color: string) => {
+  try {
+    dispatch({ type: 'SET_DRAWING_BRUSH_COLOR', payload: color })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const setDrawingBrushRadiusAction = async (radius: number) => {
+  try {
+    dispatch({ type: 'SET_DRAWING_BRUSH_RADIUS', payload: radius })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const setStickersPanelOpenAction = async (open: boolean) => {
+  try {
+    if (open && document.pointerLockElement) {
+      document.exitPointerLock()
+    }
+
+    dispatch({ type: 'SET_STICKERS_PANEL_OPEN', payload: open })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const selectStickerAction = async (stickerId?: string) => {
+  try {
+    dispatch({ type: 'SET_SELECTED_STICKER', payload: stickerId })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const startStickerDragAction = async (payload: {
+  kind: StickerDragKind
+  stickerId?: string
+  stickerClassId?: number
+  stickerTeam?: StickerTeam
+  screenX: number
+  screenY: number
+}) => {
+  try {
+    dispatch({ type: 'START_STICKER_DRAG', payload })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const cancelStickerDragAction = async () => {
+  try {
+    dispatch({ type: 'CANCEL_STICKER_DRAG' })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const addStickerAction = async (sticker: StickerAnnotation) => {
+  try {
+    dispatch({ type: 'ADD_STICKER', payload: sticker })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const moveStickerAction = async (id: string, position: [number, number, number]) => {
+  try {
+    dispatch({ type: 'MOVE_STICKER', payload: { id, position } })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const deleteStickerAction = async (id: string) => {
+  try {
+    dispatch({ type: 'DELETE_STICKER', payload: id })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const deleteSelectedStickerAction = async () => {
+  try {
+    const selectedStickerId = getState().drawing.selectedStickerId
+    if (!selectedStickerId) return
+    dispatch({ type: 'DELETE_STICKER', payload: selectedStickerId })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const clearStickersAction = async () => {
+  try {
+    if (getState().drawing.stickerHistory.present.length === 0) return
+    dispatch({ type: 'CLEAR_STICKERS' })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const undoStickersAction = async () => {
+  try {
+    if (getState().drawing.stickerHistory.past.length === 0) return
+    dispatch({ type: 'UNDO_STICKERS' })
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+export const redoStickersAction = async () => {
+  try {
+    if (getState().drawing.stickerHistory.future.length === 0) return
+    dispatch({ type: 'REDO_STICKERS' })
   } catch (error) {
     console.error(error)
   }

--- a/src/zustand/drawing.ts
+++ b/src/zustand/drawing.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_BRUSH_COLOR, DEFAULT_BRUSH_RADIUS } from '@constants/drawing'
+import { DrawingTool, StickerAnnotation, StickerTeam } from '@constants/types'
+import { HistoryState, createHistoryState } from '@utils/history'
+
+export type StickerDragKind = 'create' | 'move'
+
+export type StickerDragState = {
+  active: boolean
+  kind?: StickerDragKind
+  stickerId?: string
+  stickerClassId?: number
+  stickerTeam?: StickerTeam
+  screenX: number
+  screenY: number
+}
+
+export type DrawingState = {
+  enabled: boolean
+  tool: DrawingTool
+  brushColor: string
+  brushRadius: number
+  stickersPanelOpen: boolean
+  selectedStickerId?: string
+  stickerHistory: HistoryState<StickerAnnotation[]>
+  stickerDrag: StickerDragState
+}
+
+export function createInitialStickerDragState(): StickerDragState {
+  return {
+    active: false,
+    kind: undefined,
+    stickerId: undefined,
+    stickerClassId: undefined,
+    stickerTeam: undefined,
+    screenX: 0,
+    screenY: 0,
+  }
+}
+
+export function createInitialDrawingState(): DrawingState {
+  return {
+    enabled: false,
+    tool: DrawingTool.BRUSH,
+    brushColor: DEFAULT_BRUSH_COLOR,
+    brushRadius: DEFAULT_BRUSH_RADIUS,
+    stickersPanelOpen: false,
+    selectedStickerId: undefined,
+    stickerHistory: createHistoryState<StickerAnnotation[]>([]),
+    stickerDrag: createInitialStickerDragState(),
+  }
+}

--- a/src/zustand/reducer.ts
+++ b/src/zustand/reducer.ts
@@ -2,6 +2,9 @@ import localForage from 'localforage'
 import { set, clone, clamp, uniq, without, sortedUniq, sortBy } from 'lodash'
 
 import { StoreState, StoreAction, useInstance } from './store'
+import { StickerAnnotation } from '@constants/types'
+import { redoHistoryState, pushHistoryState, undoHistoryState } from '@utils/history'
+import { createInitialStickerDragState } from './drawing'
 
 const reducers = (state: StoreState, action: StoreAction) => {
   switch (action.type) {
@@ -42,6 +45,7 @@ const reducers = (state: StoreState, action: StoreAction) => {
         ...state,
         scene: action.payload.scene,
         playback: action.payload.playback,
+        drawing: resetDrawingStickers(state.drawing),
         bookmarks: [],
       }
 
@@ -142,8 +146,193 @@ const reducers = (state: StoreState, action: StoreAction) => {
     case 'SET_DRAWING_INACTIVE':
       return {
         ...state,
-        drawing: { ...state.drawing, enabled: false },
+        drawing: {
+          ...state.drawing,
+          enabled: false,
+          stickerDrag: createInitialStickerDragState(),
+        },
       }
+
+    case 'SET_DRAWING_TOOL':
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          tool: action.payload,
+          stickerDrag: createInitialStickerDragState(),
+        },
+      }
+
+    case 'SET_DRAWING_BRUSH_COLOR':
+      return {
+        ...state,
+        drawing: { ...state.drawing, brushColor: action.payload },
+      }
+
+    case 'SET_DRAWING_BRUSH_RADIUS':
+      return {
+        ...state,
+        drawing: { ...state.drawing, brushRadius: action.payload },
+      }
+
+    case 'SET_STICKERS_PANEL_OPEN':
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          stickersPanelOpen: action.payload,
+        },
+      }
+
+    case 'SET_SELECTED_STICKER':
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          selectedStickerId: action.payload,
+        },
+      }
+
+    case 'START_STICKER_DRAG':
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          selectedStickerId:
+            action.payload.kind === 'create'
+              ? undefined
+              : action.payload.stickerId ?? state.drawing.selectedStickerId,
+          stickerDrag: {
+            active: true,
+            kind: action.payload.kind,
+            stickerId: action.payload.stickerId,
+            stickerClassId: action.payload.stickerClassId,
+            stickerTeam: action.payload.stickerTeam,
+            screenX: action.payload.screenX,
+            screenY: action.payload.screenY,
+          },
+        },
+      }
+
+    case 'CANCEL_STICKER_DRAG':
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          stickerDrag: createInitialStickerDragState(),
+        },
+      }
+
+    case 'ADD_STICKER': {
+      const nextStickers = [...state.drawing.stickerHistory.present, action.payload]
+
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          selectedStickerId: action.payload.id,
+          stickerDrag: createInitialStickerDragState(),
+          stickerHistory: pushHistoryState(state.drawing.stickerHistory, nextStickers),
+        },
+      }
+    }
+
+    case 'MOVE_STICKER': {
+      let changed = false
+      const nextStickers = state.drawing.stickerHistory.present.map(sticker => {
+        if (sticker.id !== action.payload.id) return sticker
+        if (sameStickerPosition(sticker.position, action.payload.position)) return sticker
+        changed = true
+        return {
+          ...sticker,
+          position: action.payload.position,
+        }
+      })
+
+      if (!changed) {
+        return {
+          ...state,
+          drawing: {
+            ...state.drawing,
+            stickerDrag: createInitialStickerDragState(),
+          },
+        }
+      }
+
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          selectedStickerId: action.payload.id,
+          stickerDrag: createInitialStickerDragState(),
+          stickerHistory: pushHistoryState(state.drawing.stickerHistory, nextStickers),
+        },
+      }
+    }
+
+    case 'DELETE_STICKER': {
+      const nextStickers = state.drawing.stickerHistory.present.filter(
+        sticker => sticker.id !== action.payload
+      )
+
+      if (nextStickers.length === state.drawing.stickerHistory.present.length) return state
+
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          selectedStickerId:
+            state.drawing.selectedStickerId === action.payload
+              ? undefined
+              : state.drawing.selectedStickerId,
+          stickerHistory: pushHistoryState(state.drawing.stickerHistory, nextStickers),
+        },
+      }
+    }
+
+    case 'CLEAR_STICKERS':
+      if (state.drawing.stickerHistory.present.length === 0) return state
+
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          selectedStickerId: undefined,
+          stickerHistory: pushHistoryState(state.drawing.stickerHistory, []),
+        },
+      }
+
+    case 'UNDO_STICKERS': {
+      const stickerHistory = undoHistoryState(state.drawing.stickerHistory)
+
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          stickerHistory,
+          selectedStickerId: resolveSelectedStickerId(
+            stickerHistory.present,
+            state.drawing.selectedStickerId
+          ),
+        },
+      }
+    }
+
+    case 'REDO_STICKERS': {
+      const stickerHistory = redoHistoryState(state.drawing.stickerHistory)
+
+      return {
+        ...state,
+        drawing: {
+          ...state.drawing,
+          stickerHistory,
+          selectedStickerId: resolveSelectedStickerId(
+            stickerHistory.present,
+            state.drawing.selectedStickerId
+          ),
+        },
+      }
+    }
 
     //
     // ─── EVENT HISTORY ───────────────────────────────────────────────
@@ -211,6 +400,35 @@ const reducers = (state: StoreState, action: StoreAction) => {
     default:
       return state
   }
+}
+
+function resetDrawingStickers(drawing: StoreState['drawing']): StoreState['drawing'] {
+  return {
+    ...drawing,
+    stickersPanelOpen: false,
+    selectedStickerId: undefined,
+    stickerHistory: {
+      past: [],
+      present: [],
+      future: [],
+    },
+    stickerDrag: createInitialStickerDragState(),
+  }
+}
+
+function sameStickerPosition(
+  left: [number, number, number],
+  right: [number, number, number]
+): boolean {
+  return left[0] === right[0] && left[1] === right[1] && left[2] === right[2]
+}
+
+function resolveSelectedStickerId(
+  stickers: StickerAnnotation[],
+  selectedStickerId?: string
+): string | undefined {
+  if (!selectedStickerId) return undefined
+  return stickers.some(sticker => sticker.id === selectedStickerId) ? selectedStickerId : undefined
 }
 
 export default reducers

--- a/src/zustand/store.ts
+++ b/src/zustand/store.ts
@@ -18,6 +18,7 @@ import {
   SceneMode,
   UIPanelType,
 } from '@constants/types'
+import { DrawingState, createInitialDrawingState } from './drawing'
 import rootReducer from './reducer'
 
 // This "Instance Store" is meant to be used for larger objects that are problematic
@@ -122,9 +123,7 @@ export type StoreState = {
     forceShowPanel: boolean
     intervalPerTick: number
   }
-  drawing: {
-    enabled: boolean
-  }
+  drawing: DrawingState
   settings: {
     scene: {
       mode: SceneMode
@@ -205,9 +204,7 @@ export const initialState: StoreState = {
     intervalPerTick: 0.015,
   },
 
-  drawing: {
-    enabled: false,
-  },
+  drawing: createInitialDrawingState(),
 
   settings: {
     scene: {
@@ -249,7 +246,7 @@ export const initialState: StoreState = {
         color: '#ffffff',
       },
       playerOutlines: false,
-      showStats: false,
+      showStats: true,
       showSkybox: true,
       viewDistance: 15000,
       killfeedSeekBuffer: 2,


### PR DESCRIPTION
## Summary
- add a 3D sticker system that anchors TF2 class markers in world space and keeps them selectable and draggable as the camera moves
- move sticker creation and management out of the drawing tools panel into a dedicated playback-panel palette for easier access
- add sticker history, selection, keyboard shortcuts, deselection rules, fixed-size rendering, and smoother selection/drag interactions
- update spectator and viewer input handling so sticker interactions do not fight camera controls or brush drawing

<img width="1028" height="818" alt="image" src="https://github.com/user-attachments/assets/df4467ad-13cf-4d73-b779-6b65b6e4551d" />


## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails on pre-existing unrelated TypeScript errors in Analyse/Data files and existing unused `options` params in `src/zustand/actions.ts`)*