### PR TITLE
Load a demo from the URL (?demo= / ?demoUrl=)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,13 @@ import React from 'react'
 import { ViewerPage } from '@pages/ViewerPage'
 import {
   bootstrapSharedSetupFromHashAction,
+  goToTickAction,
   loadEmptySceneMapAction,
   loadSetupsAction,
   loadSettingsAction,
 } from '@zus/actions'
 import { getState } from '@zus/store'
+import { loadUrlDemoAction, resolveUrlDemoAction } from '@utils/embed'
 
 class App extends React.Component {
   state = {
@@ -22,9 +24,21 @@ class App extends React.Component {
     await loadSettingsAction()
     await loadSetupsAction()
     const sharedSetup = await bootstrapSharedSetupFromHashAction()
-    await loadEmptySceneMapAction(sharedSetup?.map ?? getState().scene.map)
+
+    // A demo may be requested by URL (?demo= / ?demoUrl=) — see @utils/embed. Resolving it
+    // first means the empty scene boots straight into that demo's map, instead of
+    // downloading the default map's model and discarding it seconds later.
+    const urlDemo = await resolveUrlDemoAction()
+
+    await loadEmptySceneMapAction(urlDemo?.map ?? sharedSetup?.map ?? getState().scene.map)
 
     this.setState({ isReady: true })
+
+    // Only once the viewer is mounted — the download progress overlay lives there.
+    if (urlDemo) {
+      const loaded = await loadUrlDemoAction(urlDemo)
+      if (loaded?.tick) goToTickAction(loaded.tick)
+    }
 
     // Completely disable right clicks cause it's kinda annoying
     // when interacting with UI elements

--- a/src/components/Misc/UrlDemoNotice.tsx
+++ b/src/components/Misc/UrlDemoNotice.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+
+import { UrlDemoStatus, getUrlDemoStatus, subscribeToUrlDemoStatus } from '@utils/embed'
+
+/**
+ * Status overlay for a demo requested via the URL (?demo= / ?demoUrl=).
+ *
+ * Kept out of the zustand store on purpose — nothing else needs to read this, and a plain
+ * subscription keeps the feature self-contained.
+ */
+export const UrlDemoNotice = () => {
+  const [status, setStatus] = useState<UrlDemoStatus>(getUrlDemoStatus)
+
+  useEffect(() => subscribeToUrlDemoStatus(setStatus), [])
+
+  if (status.state === 'idle') return null
+
+  return (
+    <div className="ui-layer top-20 items-start justify-center">
+      <motion.div
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.2 }}
+        className="max-w-md rounded-lg bg-pp-panel/90 px-5 py-3 text-center"
+      >
+        {status.state === 'resolving' && <div>Looking up demo ...</div>}
+
+        {status.state === 'error' && (
+          <>
+            <div className="font-bold">Couldn't load this demo</div>
+            <div className="mt-1 text-sm opacity-70">{status.message}</div>
+            {status.link && (
+              <a
+                href={status.link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-2 inline-block text-sm underline opacity-90 hover:opacity-100"
+              >
+                {status.link.label}
+              </a>
+            )}
+            <div className="mt-2 text-xs opacity-50">
+              You can still drag a <code>.dem</code> file in to watch it.
+            </div>
+          </>
+        )}
+      </motion.div>
+    </div>
+  )
+}

--- a/src/pages/ViewerPage.tsx
+++ b/src/pages/ViewerPage.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import { IoArrowForwardSharpIcon } from '@components/Misc/Icons'
 import { GlobalKeyHandler } from '@components/Misc/GlobalKeyHandler'
 import { DemoDropzone } from '@components/Misc/DemoDropzone'
+import { UrlDemoNotice } from '@components/Misc/UrlDemoNotice'
 import { DemoDrawing } from '@components/Misc/DemoDrawing'
 import { DemoViewer } from '@components/DemoViewer'
 import {
@@ -107,6 +108,9 @@ const ViewerPage = () => {
           <div>Parsing demo ... {parser.progress}%</div>
         </motion.div>
       </div>
+
+      {/* Status for a demo requested via the URL */}
+      <UrlDemoNotice />
 
       {/* Camera tip panels overlays - hidden on mobile (keyboard shortcuts not relevant) */}
       {!isMobile && (

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -1,0 +1,166 @@
+import axios from 'axios'
+
+import { addDownloadAction, updateDownloadAction, parseDemoAction } from '@zus/actions'
+
+//
+// ─── LOADING A DEMO FROM THE URL ────────────────────────────────────────────────
+//
+// Lets a demo be opened by link instead of only by drag-and-drop:
+//
+//   /?demo=693769                       a demos.tf id, resolved via their public API
+//   /?demoUrl=https://…/foo.dem         a direct .dem URL
+//   …&tick=1000                         optional tick to seek to once loaded
+//
+// This makes dribble.tf linkable from anywhere a demo is referenced — match pages,
+// forum posts, Discord — and is what an <iframe> embed needs to say which demo to show.
+//
+// The demo is fetched by the visitor's browser; demos.tf serves
+// `access-control-allow-origin: *`, so no proxy is involved.
+//
+
+const DEMOS_TF_API = 'https://api.demos.tf/demos'
+
+// ?demoUrl= is attacker-controllable, so the hosts it may point at are restricted. Nothing
+// here can reach a private network (it's a browser fetch, not server-side), but an
+// unrestricted version would turn any dribble.tf link into "fetch this arbitrary URL with
+// dribble.tf as the referrer". Extend this if you self-host demos elsewhere.
+const ALLOWED_DEMO_HOSTS = [/(^|\.)demos\.tf$/i]
+
+const isAllowedDemoUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url, window.location.origin)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false
+    if (parsed.origin === window.location.origin) return true
+    return ALLOWED_DEMO_HOSTS.some(pattern => pattern.test(parsed.hostname))
+  } catch {
+    return false
+  }
+}
+
+export type UrlDemoStatus =
+  | { state: 'idle' }
+  | { state: 'resolving' }
+  | { state: 'error'; message: string; link?: { href: string; label: string } }
+
+type UrlDemoStatusListener = (status: UrlDemoStatus) => void
+
+let urlDemoStatus: UrlDemoStatus = { state: 'idle' }
+const listeners = new Set<UrlDemoStatusListener>()
+
+export const getUrlDemoStatus = () => urlDemoStatus
+
+export const subscribeToUrlDemoStatus = (listener: UrlDemoStatusListener) => {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+const setUrlDemoStatus = (status: UrlDemoStatus) => {
+  urlDemoStatus = status
+  listeners.forEach(listener => listener(status))
+}
+
+export interface UrlDemoRequest {
+  url: string
+  name: string
+  /** Map the demo was played on, when known up front — see resolveUrlDemoAction. */
+  map?: string
+  tick: number
+  demoId?: string
+}
+
+const reportUrlDemoError = (error: unknown, demoId?: string) => {
+  console.error('[url-demo] failed to load demo', error)
+
+  setUrlDemoStatus({
+    state: 'error',
+    message:
+      error instanceof Error && error.message
+        ? error.message
+        : 'Could not load this demo. It may have been removed.',
+    link: demoId ? { href: `https://demos.tf/${demoId}`, label: 'View on demos.tf' } : undefined,
+  })
+}
+
+/**
+ * Phase 1 — work out WHAT to load, without downloading it yet.
+ *
+ * Split from the download deliberately: the demos.tf record names the map, and knowing it
+ * before the scene boots lets App load that map's geometry straight away. Otherwise the
+ * viewer downloads the default map's (multi-MB) model first and throws it away the moment
+ * the demo finishes parsing.
+ *
+ * Resolves to null when no demo was requested, so the normal drag-and-drop flow is untouched.
+ */
+export const resolveUrlDemoAction = async (): Promise<UrlDemoRequest | null> => {
+  const params = new URLSearchParams(window.location.search)
+  const demoId = params.get('demo')
+  const explicitUrl = params.get('demoUrl')
+
+  if (!demoId && !explicitUrl) return null
+
+  const tick = Number(params.get('tick')) || 0
+
+  try {
+    setUrlDemoStatus({ state: 'resolving' })
+
+    let request: UrlDemoRequest
+
+    if (demoId) {
+      // demos.tf's API is public, keyless and CORS-open. The record also carries the
+      // original filename, which reads better in the download overlay than the hashed
+      // storage path, plus the map name we want for the head start above.
+      const { data } = await axios.get(`${DEMOS_TF_API}/${encodeURIComponent(demoId)}`, {
+        responseType: 'json',
+      })
+
+      if (!data?.url) throw new Error(`demos.tf ${demoId} has no downloadable file`)
+
+      request = { url: data.url, name: data.name ?? `${demoId}.dem`, map: data.map, tick, demoId }
+    } else {
+      const url = explicitUrl as string
+      request = { url, name: decodeURIComponent(url.split('/').pop() ?? 'demo.dem'), tick }
+    }
+
+    if (!isAllowedDemoUrl(request.url)) throw new Error('That demo host is not allowed')
+
+    setUrlDemoStatus({ state: 'idle' })
+
+    return request
+  } catch (error) {
+    reportUrlDemoError(error, demoId ?? undefined)
+    return null
+  }
+}
+
+/**
+ * Phase 2 — download and parse. Must run after the viewer has mounted, so the existing
+ * download progress overlay is on screen for what is often a 50MB+ transfer.
+ *
+ * Returns the tick to seek to, which the caller applies once the scene is up.
+ */
+export const loadUrlDemoAction = async (
+  request: UrlDemoRequest
+): Promise<{ tick: number } | null> => {
+  try {
+    await addDownloadAction({ type: 'demo', url: request.url, name: request.name })
+
+    const fileBuffer = await axios
+      .get(request.url, {
+        responseType: 'arraybuffer',
+        onDownloadProgress: event => {
+          updateDownloadAction(request.url, {
+            progress: event.progress ? event.progress * 100 : 0,
+            size: event.total,
+          })
+        },
+      })
+      .then(res => res.data)
+
+    await parseDemoAction(fileBuffer)
+
+    return { tick: request.tick }
+  } catch (error) {
+    reportUrlDemoError(error, request.demoId)
+    return null
+  }
+}


### PR DESCRIPTION
Hi! Thanks for dribble.tf, and for letting us use it on [tf2esports.com](https://tf2esports.com). This is the one change we needed that seemed generally useful, so here it is rather than living only in our fork.

### What it does

Lets a demo be opened by link instead of only by drag-and-drop:

| | |
|---|---|
| `/?demo=693769` | a demos.tf id, resolved via their public API |
| `/?demoUrl=https://…/foo.dem` | a direct `.dem` URL |
| `…&tick=1000` | optional tick to seek to once loaded |

### Notes on the implementation

- **Resolution and download are two phases on purpose.** The demos.tf record names the map, so `App` can boot the empty scene straight into it. Without that, the viewer downloads the *default* map's model and throws it away the second the demo finishes parsing, a wasted multi-MB fetch on every link open.
- **Reuses your existing download overlay** (`addDownloadAction`/`updateDownloadAction`) rather than adding a second progress UI, so a 50MB+ transfer shows progress the same way the sample demo does.
- **Failures are reported in-app** via a small overlay with a link back to demos.tf, instead of a silent console error.
- **`?demoUrl=` hosts are allowlisted** (`*.demos.tf` + same-origin). Nothing here can reach a private network since it's a browser fetch, but without a list any dribble.tf link becomes "fetch this arbitrary URL with dribble.tf as the referrer".
- The status overlay deliberately keeps its state out of the zustand store, since nothing else needs to read it.

Demos are fetched by the visitor's browser; demos.tf serves `access-control-allow-origin: *`, so no proxy is involved.